### PR TITLE
feat(prime-signal): smoothdamp, spring, filters, deadzone

### DIFF
--- a/crates/prime-signal/src/lib.rs
+++ b/crates/prime-signal/src/lib.rs
@@ -1,9 +1,419 @@
-//! prime-signal — Signal processing — smoothdamp, spring, low_pass, deadzone.
+//! prime-signal — Signal processing for game feel and real-time systems.
 //!
-//! # Planned modules
-//! - `damp` — smoothdamp: critically damped spring (camera follow)
-//! - `spring` — Hooke spring simulation with damping
-//! - `filter` — Low-pass and high-pass filters
-//! - `deadzone` — Axis deadzone and response curves
+//! # Modules
+//! - [`smoothdamp`] — critically damped spring (camera follow, UI animation)
+//! - [`spring`] — Hooke spring with damping (oscillating follow)
+//! - [`low_pass`] — exponential low-pass filter (smooth noisy input)
+//! - [`high_pass`] — exponential high-pass filter (isolate fast changes)
+//! - [`deadzone`] — axis deadzone and response curve (gamepad input)
 
-// TODO: implement
+/// Smoothly damps a value toward a target using a critically damped spring.
+///
+/// This is the standard "camera follow" function — smooth, no overshoot,
+/// arrives at target with zero velocity.
+///
+/// # Math
+///
+/// Critically damped spring approximation (Runge-Kutta inspired polynomial):
+///
+///   omega = 2 / smooth_time
+///   k = 1 + omega·dt + 0.48·omega²·dt² + 0.235·omega³·dt³
+///   change = current − target
+///   temp = (velocity + omega·change) · dt
+///   new_velocity = (velocity − omega·temp) / k
+///   new_value = target + (change + temp) / k
+///
+/// The polynomial denominator `k` approximates the exact exponential decay.
+/// Error < 0.1% for typical dt values (< 0.1s).
+///
+/// # Arguments
+/// * `current` - Current value
+/// * `target` - Target value to approach
+/// * `velocity` - Current velocity (from previous frame)
+/// * `smooth_time` - Approximate time to reach target (seconds). Must be > 0.
+/// * `dt` - Delta time since last call (seconds)
+///
+/// # Returns
+/// `(new_value, new_velocity)` — store both for the next frame.
+///
+/// # Edge cases
+/// * `smooth_time <= 0` → clamps to 1e-4 to avoid division by zero
+/// * `dt == 0` → returns `(current, velocity)` unchanged
+///
+/// # Example
+/// ```rust
+/// use prime_signal::smoothdamp;
+/// let mut vel = 0.0f32;
+/// let mut pos = 0.0f32;
+/// for _ in 0..100 {
+///     (pos, vel) = smoothdamp(pos, 10.0, vel, 0.3, 0.016);
+/// }
+/// // After 100 frames at 60fps, should be very close to 10.0
+/// assert!((pos - 10.0).abs() < 0.01);
+/// ```
+pub fn smoothdamp(
+    current: f32,
+    target: f32,
+    velocity: f32,
+    smooth_time: f32,
+    dt: f32,
+) -> (f32, f32) {
+    if dt <= 0.0 { return (current, velocity); }
+    let smooth_time = smooth_time.max(1e-4);
+    let omega = 2.0 / smooth_time;
+    let x = omega * dt;
+    let k = 1.0 + x + 0.48 * x * x + 0.235 * x * x * x;
+    let change = current - target;
+    let temp = (velocity + omega * change) * dt;
+    let new_vel = (velocity - omega * temp) / k;
+    let new_val = target + (change + temp) / k;
+    (new_val, new_vel)
+}
+
+/// Spring simulation — Hooke's law with damping. Allows overshoot.
+///
+/// Unlike smoothdamp (no overshoot), spring oscillates around the target
+/// based on stiffness and damping. Use for bouncy, physical-feeling motion.
+///
+/// # Math
+///
+/// Symplectic Euler integration of Hooke's law with damping:
+///   force = −stiffness × (position − target) − damping × velocity
+///   velocity += force × dt
+///   position += velocity × dt
+///
+/// Critical damping ratio: damping = 2 × √(stiffness × mass)
+/// For mass=1: damping = 2√stiffness → no oscillation, fastest settle.
+/// Lower damping → more oscillation. Higher → slower but no bounce.
+///
+/// # Arguments
+/// * `position` - Current position
+/// * `velocity` - Current velocity
+/// * `target` - Target position
+/// * `stiffness` - Spring constant (higher = snappier). Typical: 50–500.
+/// * `damping` - Damping coefficient. Typical: 2×√stiffness for critical.
+/// * `dt` - Delta time (seconds)
+///
+/// # Returns
+/// `(new_position, new_velocity)` — store both for the next frame.
+///
+/// # Edge cases
+/// * `dt == 0` → returns `(position, velocity)` unchanged
+///
+/// # Example
+/// ```rust
+/// use prime_signal::spring;
+/// let mut pos = 0.0f32;
+/// let mut vel = 0.0f32;
+/// for _ in 0..200 {
+///     (pos, vel) = spring(pos, vel, 10.0, 100.0, 20.0, 0.016);
+/// }
+/// assert!((pos - 10.0).abs() < 0.01);
+/// ```
+pub fn spring(
+    position: f32,
+    velocity: f32,
+    target: f32,
+    stiffness: f32,
+    damping: f32,
+    dt: f32,
+) -> (f32, f32) {
+    if dt <= 0.0 { return (position, velocity); }
+    let force = -stiffness * (position - target) - damping * velocity;
+    let new_vel = velocity + force * dt;
+    let new_pos = position + new_vel * dt;
+    (new_pos, new_vel)
+}
+
+/// Exponential low-pass filter — smooths noisy or rapidly changing input.
+///
+/// # Math
+///
+/// One-pole IIR low-pass filter:
+///   alpha = 1 − e^(−dt / time_constant)
+///   output = previous + alpha × (input − previous)
+///         = lerp(previous, input, alpha)
+///
+/// alpha → 0: heavy smoothing (slow response)
+/// alpha → 1: no smoothing (instant response)
+///
+/// time_constant is the RC constant: time for output to reach ~63% of
+/// a step input. Higher time_constant → more smoothing.
+///
+/// # Arguments
+/// * `previous` - Last filtered output (store between calls)
+/// * `input` - New raw input sample
+/// * `time_constant` - Smoothing time constant (seconds). Must be > 0.
+/// * `dt` - Delta time (seconds)
+///
+/// # Returns
+/// New filtered value. Store this as `previous` for the next call.
+///
+/// # Edge cases
+/// * `time_constant <= 0` → clamps to 1e-6
+/// * `dt == 0` → returns `previous` unchanged
+///
+/// # Example
+/// ```rust
+/// use prime_signal::low_pass;
+/// let mut filtered = 0.0f32;
+/// for _ in 0..200 {
+///     filtered = low_pass(filtered, 1.0, 0.1, 0.016);
+/// }
+/// assert!((filtered - 1.0).abs() < 0.01);
+/// ```
+pub fn low_pass(previous: f32, input: f32, time_constant: f32, dt: f32) -> f32 {
+    if dt <= 0.0 { return previous; }
+    let tc = time_constant.max(1e-6);
+    let alpha = 1.0 - (-dt / tc).exp();
+    previous + alpha * (input - previous)
+}
+
+/// Exponential high-pass filter — isolates fast changes, removes DC offset.
+///
+/// # Math
+///
+/// Derived from low-pass complement:
+///   lp = low_pass(previous_lp, input, time_constant, dt)
+///   output = input − lp
+///
+/// Passes high-frequency changes, blocks slow drift.
+/// Use for: detecting sudden inputs, removing gravity from accelerometer,
+/// isolating transients from a signal.
+///
+/// # Arguments
+/// * `previous_lp` - Last low-pass state (from previous frame)
+/// * `input` - New raw input sample
+/// * `time_constant` - Cutoff time constant (seconds)
+/// * `dt` - Delta time (seconds)
+///
+/// # Returns
+/// `(output, new_lp_state)` — store `new_lp_state` for the next frame.
+///
+/// # Example
+/// ```rust
+/// use prime_signal::high_pass;
+/// let mut lp_state = 0.0f32;
+/// // DC signal — high pass should output ~0 after settling
+/// let mut out = 0.0f32;
+/// for _ in 0..200 {
+///     (out, lp_state) = high_pass(lp_state, 1.0, 0.05, 0.016);
+/// }
+/// assert!(out.abs() < 0.01);
+/// ```
+pub fn high_pass(previous_lp: f32, input: f32, time_constant: f32, dt: f32) -> (f32, f32) {
+    let new_lp = low_pass(previous_lp, input, time_constant, dt);
+    (input - new_lp, new_lp)
+}
+
+/// Apply deadzone and response curve to a raw axis value.
+///
+/// # Math
+///
+/// Given raw value r in [−1, 1]:
+///   if |r| < deadzone  → output = 0  (stick at rest, ignore noise)
+///   else               → remap |r| from [deadzone, 1] → [0, 1],
+///                        preserve sign,
+///                        apply power curve: output = sign × t^curve
+///
+/// curve = 1.0 → linear response after deadzone
+/// curve = 2.0 → quadratic (slow near deadzone, fast at max)
+/// curve = 0.5 → square root (fast near deadzone, leveling off)
+///
+/// # Arguments
+/// * `value` - Raw axis value in [−1, 1]
+/// * `deadzone` - Deadzone threshold in [0, 1). Values below this → 0.
+/// * `curve` - Response curve exponent. 1.0 = linear, 2.0 = quadratic.
+///
+/// # Returns
+/// Processed value in [−1, 1] with deadzone applied and curve shaped.
+///
+/// # Edge cases
+/// * `value` outside [−1, 1] → clamped
+/// * `deadzone >= 1.0` → always returns 0
+/// * `curve <= 0` → clamped to 0.01 to avoid undefined behavior
+///
+/// # Example
+/// ```rust
+/// use prime_signal::deadzone;
+/// assert_eq!(deadzone(0.05, 0.1, 1.0), 0.0); // inside deadzone
+/// assert!((deadzone(1.0, 0.1, 1.0) - 1.0).abs() < 1e-5); // full deflection
+/// assert_eq!(deadzone(-0.05, 0.1, 1.0), 0.0); // negative inside deadzone
+/// ```
+pub fn deadzone(value: f32, deadzone: f32, curve: f32) -> f32 {
+    let v = value.clamp(-1.0, 1.0);
+    let dz = deadzone.clamp(0.0, 0.9999);
+    let curve = curve.max(0.01);
+    let abs = v.abs();
+    if abs < dz { return 0.0; }
+    let t = (abs - dz) / (1.0 - dz);
+    let shaped = t.powf(curve);
+    v.signum() * shaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON: f32 = 1e-4;
+
+    // ── smoothdamp ──
+
+    #[test]
+    fn smoothdamp_approaches_target() {
+        let (mut pos, mut vel) = (0.0f32, 0.0f32);
+        for _ in 0..200 {
+            (pos, vel) = smoothdamp(pos, 10.0, vel, 0.3, 0.016);
+        }
+        assert!((pos - 10.0).abs() < 0.01, "pos={pos}");
+    }
+
+    #[test]
+    fn smoothdamp_no_overshoot() {
+        let (mut pos, mut vel) = (0.0f32, 0.0f32);
+        let mut max_pos = 0.0f32;
+        for _ in 0..300 {
+            (pos, vel) = smoothdamp(pos, 10.0, vel, 0.3, 0.016);
+            max_pos = max_pos.max(pos);
+        }
+        assert!(max_pos <= 10.0 + 0.001, "smoothdamp overshot: max={max_pos}");
+    }
+
+    #[test]
+    fn smoothdamp_dt_zero_returns_current() {
+        let (pos, _) = smoothdamp(3.0, 10.0, 5.0, 0.3, 0.0);
+        assert!((pos - 3.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn smoothdamp_negative_smooth_time_clamped() {
+        // Should not panic
+        let _ = smoothdamp(0.0, 10.0, 0.0, -1.0, 0.016);
+    }
+
+    #[test]
+    fn smoothdamp_velocity_decays_to_zero() {
+        let (mut pos, mut vel) = (0.0f32, 0.0f32);
+        for _ in 0..500 {
+            (pos, vel) = smoothdamp(pos, 10.0, vel, 0.3, 0.016);
+        }
+        assert!(vel.abs() < 0.001, "velocity should decay to ~0, got {vel}");
+    }
+
+    // ── spring ──
+
+    #[test]
+    fn spring_approaches_target() {
+        let (mut pos, mut vel) = (0.0f32, 0.0f32);
+        for _ in 0..500 {
+            (pos, vel) = spring(pos, vel, 10.0, 100.0, 20.0, 0.016);
+        }
+        assert!((pos - 10.0).abs() < 0.01, "pos={pos}");
+    }
+
+    #[test]
+    fn spring_dt_zero_no_change() {
+        let (pos, vel) = spring(3.0, 5.0, 10.0, 100.0, 20.0, 0.0);
+        assert!((pos - 3.0).abs() < EPSILON);
+        assert!((vel - 5.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn spring_underdamped_overshoots() {
+        let (mut pos, mut vel) = (0.0f32, 0.0f32);
+        let mut max_pos = 0.0f32;
+        for _ in 0..100 {
+            (pos, vel) = spring(pos, vel, 10.0, 200.0, 5.0, 0.016);
+            max_pos = max_pos.max(pos);
+        }
+        assert!(max_pos > 10.0, "underdamped spring should overshoot, max={max_pos}");
+    }
+
+    // ── low_pass ──
+
+    #[test]
+    fn low_pass_converges_to_input() {
+        let mut filtered = 0.0f32;
+        for _ in 0..300 {
+            filtered = low_pass(filtered, 1.0, 0.1, 0.016);
+        }
+        assert!((filtered - 1.0).abs() < 0.01, "filtered={filtered}");
+    }
+
+    #[test]
+    fn low_pass_dt_zero_returns_previous() {
+        let result = low_pass(0.5, 1.0, 0.1, 0.0);
+        assert!((result - 0.5).abs() < EPSILON);
+    }
+
+    #[test]
+    fn low_pass_large_time_constant_is_slow() {
+        let filtered = low_pass(0.0, 1.0, 10.0, 0.016);
+        assert!(filtered < 0.01, "large TC should respond slowly: {filtered}");
+    }
+
+    #[test]
+    fn low_pass_small_time_constant_is_fast() {
+        let filtered = low_pass(0.0, 1.0, 0.001, 0.016);
+        assert!(filtered > 0.9, "small TC should respond fast: {filtered}");
+    }
+
+    // ── high_pass ──
+
+    #[test]
+    fn high_pass_dc_signal_approaches_zero() {
+        let (mut out, mut lp) = (0.0f32, 0.0f32);
+        for _ in 0..300 {
+            (out, lp) = high_pass(lp, 1.0, 0.05, 0.016);
+        }
+        assert!(out.abs() < 0.01, "HP of DC signal should → 0, got {out}");
+    }
+
+    #[test]
+    fn high_pass_step_produces_initial_output() {
+        let (out, _) = high_pass(0.0, 1.0, 0.1, 0.016);
+        assert!(out > 0.0, "HP of step should produce positive output");
+    }
+
+    // ── deadzone ──
+
+    #[test]
+    fn deadzone_inside_returns_zero() {
+        assert_eq!(deadzone(0.05, 0.1, 1.0), 0.0);
+        assert_eq!(deadzone(-0.05, 0.1, 1.0), 0.0);
+        assert_eq!(deadzone(0.0, 0.1, 1.0), 0.0);
+    }
+
+    #[test]
+    fn deadzone_full_deflection_returns_one() {
+        assert!((deadzone(1.0, 0.1, 1.0) - 1.0).abs() < EPSILON);
+        assert!((deadzone(-1.0, 0.1, 1.0) - (-1.0)).abs() < EPSILON);
+    }
+
+    #[test]
+    fn deadzone_preserves_sign() {
+        assert!(deadzone(0.5, 0.1, 1.0) > 0.0);
+        assert!(deadzone(-0.5, 0.1, 1.0) < 0.0);
+    }
+
+    #[test]
+    fn deadzone_at_boundary() {
+        // Exactly at deadzone threshold → 0
+        assert_eq!(deadzone(0.1, 0.1, 1.0), 0.0);
+    }
+
+    #[test]
+    fn deadzone_clamps_input() {
+        // Value > 1.0 should be clamped
+        let v = deadzone(2.0, 0.1, 1.0);
+        assert!((v - 1.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn deadzone_quadratic_curve() {
+        // curve=2 should give smaller values near deadzone than linear
+        let linear = deadzone(0.55, 0.1, 1.0);
+        let quad = deadzone(0.55, 0.1, 2.0);
+        assert!(quad < linear, "quadratic curve should be smaller near deadzone");
+    }
+}

--- a/packages/prime-signal/package.json
+++ b/packages/prime-signal/package.json
@@ -9,5 +9,9 @@
     "build": "tsc",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/prime-signal/src/__tests__/signal.test.ts
+++ b/packages/prime-signal/src/__tests__/signal.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { smoothdamp, spring, lowPass, highPass, deadzone } from '../index.js'
+
+const EPS = 1e-4
+
+describe('smoothdamp', () => {
+  it('approaches target over time', () => {
+    const [pos] = Array.from({ length: 200 }).reduce(
+      ([p, v]: [number, number]) => smoothdamp(p, 10, v, 0.3, 0.016),
+      [0, 0] as [number, number],
+    )
+    expect(Math.abs(pos - 10)).toBeLessThan(0.01)
+  })
+
+  it('does not overshoot', () => {
+    const { maxPos } = Array.from({ length: 300 }).reduce(
+      ({ pos, vel, maxPos }: { pos: number; vel: number; maxPos: number }) => {
+        const [p, v] = smoothdamp(pos, 10, vel, 0.3, 0.016)
+        return { pos: p, vel: v, maxPos: Math.max(maxPos, p) }
+      },
+      { pos: 0, vel: 0, maxPos: 0 },
+    )
+    expect(maxPos).toBeLessThanOrEqual(10.001)
+  })
+
+  it('returns current when dt=0', () => {
+    const [val] = smoothdamp(3, 10, 5, 0.3, 0)
+    expect(val).toBeCloseTo(3, 4)
+  })
+
+  it('velocity decays to zero', () => {
+    const [, vel] = Array.from({ length: 500 }).reduce(
+      ([p, v]: [number, number]) => smoothdamp(p, 10, v, 0.3, 0.016),
+      [0, 0] as [number, number],
+    )
+    expect(Math.abs(vel)).toBeLessThan(0.001)
+  })
+
+  it('handles negative smooth time without throwing', () => {
+    expect(() => smoothdamp(0, 10, 0, -1, 0.016)).not.toThrow()
+  })
+})
+
+describe('spring', () => {
+  it('approaches target', () => {
+    const [pos] = Array.from({ length: 500 }).reduce(
+      ([p, v]: [number, number]) => spring(p, v, 10, 100, 20, 0.016),
+      [0, 0] as [number, number],
+    )
+    expect(Math.abs(pos - 10)).toBeLessThan(0.01)
+  })
+
+  it('no change when dt=0', () => {
+    const [pos, vel] = spring(3, 5, 10, 100, 20, 0)
+    expect(pos).toBeCloseTo(3, 4)
+    expect(vel).toBeCloseTo(5, 4)
+  })
+
+  it('underdamped spring overshoots', () => {
+    const { max } = Array.from({ length: 100 }).reduce(
+      ({ pos, vel, max }: { pos: number; vel: number; max: number }) => {
+        const [p, v] = spring(pos, vel, 10, 200, 5, 0.016)
+        return { pos: p, vel: v, max: Math.max(max, p) }
+      },
+      { pos: 0, vel: 0, max: 0 },
+    )
+    expect(max).toBeGreaterThan(10)
+  })
+})
+
+describe('lowPass', () => {
+  it('converges to input', () => {
+    const f = Array.from({ length: 300 }).reduce(
+      (prev: number) => lowPass(prev, 1, 0.1, 0.016),
+      0,
+    )
+    expect(Math.abs(f - 1)).toBeLessThan(0.01)
+  })
+
+  it('returns previous when dt=0', () => {
+    expect(lowPass(0.5, 1, 0.1, 0)).toBeCloseTo(0.5, 4)
+  })
+
+  it('large time constant responds slowly', () => {
+    expect(lowPass(0, 1, 10, 0.016)).toBeLessThan(0.01)
+  })
+
+  it('small time constant responds fast', () => {
+    expect(lowPass(0, 1, 0.001, 0.016)).toBeGreaterThan(0.9)
+  })
+})
+
+describe('highPass', () => {
+  it('DC signal approaches zero', () => {
+    const [out] = Array.from({ length: 300 }).reduce(
+      ([, lp]: [number, number]) => highPass(lp, 1, 0.05, 0.016),
+      [0, 0] as [number, number],
+    )
+    expect(Math.abs(out)).toBeLessThan(0.01)
+  })
+
+  it('step produces non-zero initial output', () => {
+    const [out] = highPass(0, 1, 0.1, 0.016)
+    expect(out).toBeGreaterThan(0)
+  })
+})
+
+describe('deadzone', () => {
+  it('returns 0 inside deadzone', () => {
+    expect(deadzone(0.05, 0.1)).toBe(0)
+    expect(deadzone(-0.05, 0.1)).toBe(0)
+    expect(deadzone(0, 0.1)).toBe(0)
+  })
+
+  it('returns ±1 at full deflection', () => {
+    expect(deadzone(1, 0.1)).toBeCloseTo(1, 4)
+    expect(deadzone(-1, 0.1)).toBeCloseTo(-1, 4)
+  })
+
+  it('preserves sign', () => {
+    expect(deadzone(0.5, 0.1)).toBeGreaterThan(0)
+    expect(deadzone(-0.5, 0.1)).toBeLessThan(0)
+  })
+
+  it('value at exact threshold returns 0', () => {
+    expect(deadzone(0.1, 0.1)).toBe(0)
+  })
+
+  it('quadratic curve smaller than linear near threshold', () => {
+    expect(deadzone(0.55, 0.1, 2)).toBeLessThan(deadzone(0.55, 0.1, 1))
+  })
+})

--- a/packages/prime-signal/src/index.ts
+++ b/packages/prime-signal/src/index.ts
@@ -1,2 +1,181 @@
-// TODO: implement
-export {};
+/**
+ * prime-signal — Signal processing for game feel and real-time systems.
+ */
+
+/**
+ * Smoothly damps a value toward a target. No overshoot.
+ *
+ * @remarks
+ * Critically damped spring approximation:
+ *   omega = 2 / smoothTime
+ *   k = 1 + omega·dt + 0.48·omega²·dt² + 0.235·omega³·dt³
+ *   change = current − target
+ *   temp = (velocity + omega·change)·dt
+ *   newVelocity = (velocity − omega·temp) / k
+ *   newValue = target + (change + temp) / k
+ *
+ * @param current - Current value
+ * @param target - Target to approach
+ * @param velocity - Velocity from the previous frame
+ * @param smoothTime - Approx time to reach target (seconds)
+ * @param dt - Delta time (seconds)
+ * @returns `[newValue, newVelocity]` — store both for the next frame
+ *
+ * @example
+ * // Accumulate over frames with reduce:
+ * const [pos] = Array.from({ length: 60 }).reduce(
+ *   ([p, v]: [number, number]) => smoothdamp(p, 10, v, 0.3, 0.016),
+ *   [0, 0] as [number, number]
+ * )
+ */
+export const smoothdamp = (
+  current: number,
+  target: number,
+  velocity: number,
+  smoothTime: number,
+  dt: number,
+): [number, number] => {
+  if (dt <= 0) return [current, velocity]
+  const st = Math.max(smoothTime, 1e-4)
+  const omega = 2 / st
+  const x = omega * dt
+  const k = 1 + x + 0.48 * x * x + 0.235 * x * x * x
+  const change = current - target
+  const temp = (velocity + omega * change) * dt
+  const newVel = (velocity - omega * temp) / k
+  const newVal = target + (change + temp) / k
+  return [newVal, newVel]
+}
+
+/**
+ * Spring simulation — Hooke's law with damping. Allows overshoot.
+ *
+ * @remarks
+ * Symplectic Euler:
+ *   force = −stiffness × (position − target) − damping × velocity
+ *   velocity += force × dt
+ *   position += velocity × dt
+ *
+ * Critical damping: damping = 2 × √stiffness (mass = 1).
+ * Lower damping → oscillation. Higher → overdamped (slow).
+ *
+ * @param position - Current position
+ * @param velocity - Current velocity
+ * @param target - Target position
+ * @param stiffness - Spring constant. Typical: 50–500.
+ * @param damping - Damping. Critical: 2×√stiffness.
+ * @param dt - Delta time (seconds)
+ * @returns `[newPosition, newVelocity]` — store both for the next frame
+ *
+ * @example
+ * const [pos] = Array.from({ length: 60 }).reduce(
+ *   ([p, v]: [number, number]) => spring(p, v, 10, 100, 20, 0.016),
+ *   [0, 0] as [number, number]
+ * )
+ */
+export const spring = (
+  position: number,
+  velocity: number,
+  target: number,
+  stiffness: number,
+  damping: number,
+  dt: number,
+): [number, number] => {
+  if (dt <= 0) return [position, velocity]
+  const force = -stiffness * (position - target) - damping * velocity
+  const newVel = velocity + force * dt
+  const newPos = position + newVel * dt
+  return [newPos, newVel]
+}
+
+/**
+ * Exponential low-pass filter — smooths noisy input.
+ *
+ * @remarks
+ * One-pole IIR:
+ *   alpha = 1 − e^(−dt / timeConstant)
+ *   output = previous + alpha × (input − previous)
+ *
+ * Higher timeConstant → more smoothing (slower response).
+ *
+ * @param previous - Last filtered value (store between calls)
+ * @param input - New raw input
+ * @param timeConstant - RC time constant (seconds)
+ * @param dt - Delta time (seconds)
+ * @returns New filtered value
+ *
+ * @example
+ * const filtered = Array.from({ length: 60 }).reduce(
+ *   (prev: number) => lowPass(prev, 1.0, 0.1, 0.016),
+ *   0
+ * )
+ */
+export const lowPass = (
+  previous: number,
+  input: number,
+  timeConstant: number,
+  dt: number,
+): number => {
+  if (dt <= 0) return previous
+  const tc = Math.max(timeConstant, 1e-6)
+  const alpha = 1 - Math.exp(-dt / tc)
+  return previous + alpha * (input - previous)
+}
+
+/**
+ * Exponential high-pass filter — isolates fast changes, removes DC offset.
+ *
+ * @remarks
+ * HP = input − LP(input)
+ * Passes rapid changes, blocks slow drift.
+ *
+ * @param previousLp - Last low-pass state (from previous frame)
+ * @param input - New raw input
+ * @param timeConstant - Cutoff time constant (seconds)
+ * @param dt - Delta time (seconds)
+ * @returns `[output, newLpState]` — store `newLpState` for the next frame
+ *
+ * @example
+ * const [fast] = Array.from({ length: 60 }).reduce(
+ *   ([, lp]: [number, number]) => highPass(lp, rawInput, 0.05, 0.016),
+ *   [0, 0] as [number, number],
+ * )
+ */
+export const highPass = (
+  previousLp: number,
+  input: number,
+  timeConstant: number,
+  dt: number,
+): [number, number] => {
+  const newLp = lowPass(previousLp, input, timeConstant, dt)
+  return [input - newLp, newLp]
+}
+
+/**
+ * Apply deadzone and response curve to a raw axis value.
+ *
+ * @remarks
+ * Given raw value r in [−1, 1]:
+ *   if |r| < deadzone → 0
+ *   else → sign × ((|r| − deadzone) / (1 − deadzone))^curve
+ *
+ * curve=1 → linear, curve=2 → quadratic, curve=0.5 → sqrt
+ *
+ * @param value - Raw axis in [−1, 1]
+ * @param dz - Deadzone threshold in [0, 1)
+ * @param curve - Response curve exponent (default 1.0)
+ * @returns Processed value in [−1, 1]
+ *
+ * @example
+ * deadzone(0.05, 0.1)  // 0 — inside deadzone
+ * deadzone(1.0, 0.1)   // 1 — full deflection
+ */
+export const deadzone = (value: number, dz: number, curve = 1.0): number => {
+  const v = Math.max(-1, Math.min(1, value))
+  const d = Math.max(0, Math.min(0.9999, dz))
+  const c = Math.max(0.01, curve)
+  const abs = Math.abs(v)
+  if (abs < d) return 0
+  const t = (abs - d) / (1 - d)
+  return Math.sign(v) * Math.pow(t, c)
+}

--- a/packages/prime-signal/tsconfig.json
+++ b/packages/prime-signal/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/prime-signal/vitest.config.ts
+++ b/packages/prime-signal/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vitest/config'
+export default defineConfig({
+  test: { globals: false, environment: 'node' },
+})


### PR DESCRIPTION
## Summary
- `smoothdamp` — critically damped spring, no overshoot, [position, velocity] tuple
- `spring` — Hooke's law with damping, allows overshoot
- `lowPass` / `highPass` — one-pole IIR, state threads forward as explicit param
- `deadzone` — axis processing with response curve
- 20 Rust tests + 5 doc tests, 19 TS tests

## Stack
Part 4/8 — stacks on `feat/prime-interp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)