### PR TITLE
feat(prime-osc): LFO shapes + ADSR envelope — unblocks Score

### DIFF
--- a/crates/prime-osc/src/lib.rs
+++ b/crates/prime-osc/src/lib.rs
@@ -1,8 +1,388 @@
-//! prime-osc — Oscillators — LFO shapes, ADSR envelope.
+//! prime-osc — Oscillators and envelopes.
 //!
-//! # Planned modules
-//! - `lfo` — LFO shapes: sine, triangle, sawtooth, square, noise
-//! - `adsr` — ADSR envelope: attack, decay, sustain, release
-//! - `ramp` — Linear and exponential ramp generators
+//! All public functions are LOAD + COMPUTE. No STORE. No JUMP.
+//! State threads forward as an explicit parameter. Same inputs → same output.
 
-// TODO: implement
+use std::f32::consts::TAU;
+
+// ── LFO shape functions ──────────────────────────────────────────────────────
+
+/// Sine wave at normalised phase.
+///
+/// # Math
+///   y = sin(phase × 2π)
+///
+/// # Arguments
+/// * `phase` - Normalised phase in [0, 1). Wraps automatically.
+///
+/// # Returns
+/// Value in [-1, 1].
+///
+/// # Example
+/// ```rust
+/// let y = prime_osc::lfo_sine(0.25); // ≈ 1.0 — quarter cycle
+/// assert!((y - 1.0).abs() < 1e-5);
+/// ```
+pub fn lfo_sine(phase: f32) -> f32 {
+    (phase * TAU).sin()
+}
+
+/// Triangle wave at normalised phase. Phase-aligned with lfo_sine (peak at 0.25).
+///
+/// # Math
+///   p = frac(phase + 0.75)
+///   y = 2 × |2p − 1| − 1
+///
+/// # Arguments
+/// * `phase` - Normalised phase in [0, 1). Wraps automatically.
+///
+/// # Returns
+/// Value in [-1, 1]. Zero at phase=0, peaks at phase=0.25, troughs at phase=0.75.
+///
+/// # Example
+/// ```rust
+/// let y = prime_osc::lfo_triangle(0.25); // 1.0 — peak
+/// assert!((y - 1.0).abs() < 1e-5);
+/// ```
+pub fn lfo_triangle(phase: f32) -> f32 {
+    let p = (phase + 0.75) - (phase + 0.75).floor();
+    2.0 * (2.0 * p - 1.0).abs() - 1.0
+}
+
+/// Sawtooth wave at normalised phase (rising).
+///
+/// # Math
+///   y = 2 × frac(phase) − 1
+///
+/// # Arguments
+/// * `phase` - Normalised phase in [0, 1). Wraps automatically.
+///
+/// # Returns
+/// Value in [-1, 1). Rises from -1 to +1, resets at each cycle.
+///
+/// # Example
+/// ```rust
+/// let y = prime_osc::lfo_sawtooth(0.0); // -1.0 — start of cycle
+/// assert!((y + 1.0).abs() < 1e-5);
+/// ```
+pub fn lfo_sawtooth(phase: f32) -> f32 {
+    let p = phase - phase.floor();
+    2.0 * p - 1.0
+}
+
+/// Square wave at normalised phase.
+///
+/// # Math
+///   y = +1 if frac(phase) < width, else -1
+///
+/// # Arguments
+/// * `phase` - Normalised phase in [0, 1).
+/// * `width` - Duty cycle in (0, 1). 0.5 = 50% square. Clamped to (0.001, 0.999).
+///
+/// # Returns
+/// Value in {-1, +1}.
+///
+/// # Edge cases
+/// * `width=0.5` → symmetric square wave
+///
+/// # Example
+/// ```rust
+/// let y = prime_osc::lfo_square(0.1, 0.5); // 1.0 — first half of cycle
+/// assert!((y - 1.0).abs() < 1e-5);
+/// ```
+pub fn lfo_square(phase: f32, width: f32) -> f32 {
+    let p = phase - phase.floor();
+    let w = width.clamp(0.001, 0.999);
+    if p < w { 1.0 } else { -1.0 }
+}
+
+// ── Oscillator step ──────────────────────────────────────────────────────────
+
+/// Advance oscillator phase by one sample and return (sample, new_phase).
+///
+/// # Math
+///   new_phase = frac(phase + freq / sample_rate)
+///   y = shape(new_phase)
+///
+/// # Arguments
+/// * `phase` - Current phase in [0, 1).
+/// * `freq` - Frequency in Hz.
+/// * `sample_rate` - Sample rate in Hz (e.g. 44100.0).
+/// * `shape` - Shape function — lfo_sine, lfo_triangle, etc.
+///
+/// # Returns
+/// `(sample, new_phase)` — thread `new_phase` into the next call.
+///
+/// # Example
+/// ```rust
+/// let (y, next) = prime_osc::osc_step(0.0, 440.0, 44100.0, prime_osc::lfo_sine);
+/// ```
+pub fn osc_step(phase: f32, freq: f32, sample_rate: f32, shape: fn(f32) -> f32) -> (f32, f32) {
+    let sr = sample_rate.max(1.0);
+    let new_phase = (phase + freq / sr).fract();
+    (shape(new_phase), new_phase)
+}
+
+// ── ADSR envelope ────────────────────────────────────────────────────────────
+
+/// ADSR envelope parameters. All times in seconds.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AdsrParams {
+    /// Attack time (0 → peak in seconds)
+    pub attack: f32,
+    /// Decay time (peak → sustain in seconds)
+    pub decay: f32,
+    /// Sustain level [0, 1]
+    pub sustain: f32,
+    /// Release time (sustain → 0 in seconds)
+    pub release: f32,
+}
+
+/// ADSR envelope stage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdsrStage {
+    Attack,
+    Decay,
+    Sustain,
+    Release,
+    Done,
+}
+
+/// ADSR envelope state. Thread forward with each call to `adsr_step`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AdsrState {
+    /// Current envelope stage.
+    pub stage: AdsrStage,
+    /// Current envelope value in [0, 1].
+    pub value: f32,
+    /// Time elapsed in the current stage (seconds).
+    pub elapsed: f32,
+}
+
+impl AdsrState {
+    /// Initial state — envelope at rest (gate off).
+    pub const IDLE: Self = Self {
+        stage: AdsrStage::Done,
+        value: 0.0,
+        elapsed: 0.0,
+    };
+}
+
+/// Advance ADSR envelope by one time step — pure LOAD + COMPUTE.
+///
+/// # Math
+///   Attack:  value += dt / attack
+///   Decay:   value = lerp(1, sustain, elapsed / decay)
+///   Sustain: value = sustain
+///   Release: value = sustain_at_release × (1 − elapsed / release)
+///   Done:    value = 0
+///
+/// # Arguments
+/// * `state` - Current envelope state.
+/// * `params` - ADSR parameters.
+/// * `gate` - true = note on, false = note off (trigger release).
+/// * `dt` - Delta time in seconds.
+///
+/// # Returns
+/// `(value, new_state)` — thread `new_state` forward.
+///
+/// # Edge cases
+/// * Gate goes false mid-attack → transitions immediately to release.
+/// * Zero attack time → jumps directly to decay in one step.
+///
+/// # Example
+/// ```rust
+/// use prime_osc::{AdsrState, AdsrParams, adsr_step};
+/// let params = AdsrParams { attack: 0.1, decay: 0.1, sustain: 0.7, release: 0.2 };
+/// let (v, s1) = adsr_step(AdsrState::IDLE, &params, true, 0.016);
+/// assert!(v > 0.0);
+/// ```
+pub fn adsr_step(state: AdsrState, params: &AdsrParams, gate: bool, dt: f32) -> (f32, AdsrState) {
+    let attack = params.attack.max(1e-4);
+    let decay = params.decay.max(1e-4);
+    let release = params.release.max(1e-4);
+    let sustain = params.sustain.clamp(0.0, 1.0);
+
+    match (state.stage, gate) {
+        // Gate off → begin or continue release from current level
+        (AdsrStage::Done, false) => (0.0, AdsrState::IDLE),
+
+        (_, false) if state.stage != AdsrStage::Release && state.stage != AdsrStage::Done => {
+            // Transition into release — preserve current value as start point
+            let new_state = AdsrState {
+                stage: AdsrStage::Release,
+                value: state.value,
+                elapsed: 0.0,
+            };
+            (state.value, new_state)
+        }
+
+        (AdsrStage::Release, false) => {
+            let t = (state.elapsed / release).min(1.0);
+            let new_val = state.value * (1.0 - t);
+            let new_elapsed = state.elapsed + dt;
+            if new_elapsed >= release {
+                (0.0, AdsrState::IDLE)
+            } else {
+                (new_val, AdsrState { stage: AdsrStage::Release, value: state.value, elapsed: new_elapsed })
+            }
+        }
+
+        // Gate on
+        (AdsrStage::Done, true) | (AdsrStage::Release, true) => {
+            // (Re-)trigger: restart from attack
+            let new_elapsed = state.elapsed + dt;
+            let new_val = (new_elapsed / attack).min(1.0);
+            if new_elapsed >= attack {
+                (1.0, AdsrState { stage: AdsrStage::Decay, value: 1.0, elapsed: 0.0 })
+            } else {
+                (new_val, AdsrState { stage: AdsrStage::Attack, value: new_val, elapsed: new_elapsed })
+            }
+        }
+
+        (AdsrStage::Attack, true) => {
+            let new_elapsed = state.elapsed + dt;
+            let new_val = (new_elapsed / attack).min(1.0);
+            if new_elapsed >= attack {
+                (1.0, AdsrState { stage: AdsrStage::Decay, value: 1.0, elapsed: 0.0 })
+            } else {
+                (new_val, AdsrState { stage: AdsrStage::Attack, value: new_val, elapsed: new_elapsed })
+            }
+        }
+
+        (AdsrStage::Decay, true) => {
+            let new_elapsed = state.elapsed + dt;
+            let t = (new_elapsed / decay).min(1.0);
+            let new_val = 1.0 + (sustain - 1.0) * t;
+            if new_elapsed >= decay {
+                (sustain, AdsrState { stage: AdsrStage::Sustain, value: sustain, elapsed: 0.0 })
+            } else {
+                (new_val, AdsrState { stage: AdsrStage::Decay, value: new_val, elapsed: new_elapsed })
+            }
+        }
+
+        (AdsrStage::Sustain, true) => {
+            (sustain, AdsrState { stage: AdsrStage::Sustain, value: sustain, elapsed: state.elapsed + dt })
+        }
+
+        // Catch-all (shouldn't be reachable)
+        _ => (0.0, AdsrState::IDLE),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const EPS: f32 = 1e-5;
+
+    // lfo_sine
+    #[test]
+    fn sine_zero_phase() { assert!((lfo_sine(0.0)).abs() < EPS); }
+    #[test]
+    fn sine_quarter_phase() { assert!((lfo_sine(0.25) - 1.0).abs() < EPS); }
+    #[test]
+    fn sine_half_phase() { assert!((lfo_sine(0.5)).abs() < EPS); }
+    #[test]
+    fn sine_three_quarter_phase() { assert!((lfo_sine(0.75) + 1.0).abs() < EPS); }
+    #[test]
+    fn sine_range() {
+        (0..1000).map(|i| lfo_sine(i as f32 / 1000.0))
+            .for_each(|v| { assert!(v >= -1.0 - EPS && v <= 1.0 + EPS); });
+    }
+
+    // lfo_triangle
+    #[test]
+    fn triangle_zero() { assert!((lfo_triangle(0.0)).abs() < EPS); }
+    #[test]
+    fn triangle_quarter() { assert!((lfo_triangle(0.25) - 1.0).abs() < EPS); }
+    #[test]
+    fn triangle_half() { assert!((lfo_triangle(0.5)).abs() < EPS); }
+    #[test]
+    fn triangle_three_quarter() { assert!((lfo_triangle(0.75) + 1.0).abs() < EPS); }
+    #[test]
+    fn triangle_range() {
+        (0..1000).map(|i| lfo_triangle(i as f32 / 1000.0))
+            .for_each(|v| { assert!(v >= -1.0 - EPS && v <= 1.0 + EPS); });
+    }
+
+    // lfo_sawtooth
+    #[test]
+    fn sawtooth_zero() { assert!((lfo_sawtooth(0.0) + 1.0).abs() < EPS); }
+    #[test]
+    fn sawtooth_half() { assert!((lfo_sawtooth(0.5)).abs() < EPS); }
+    #[test]
+    fn sawtooth_range() {
+        (0..1000).map(|i| lfo_sawtooth(i as f32 / 1000.0))
+            .for_each(|v| { assert!(v >= -1.0 - EPS && v <= 1.0 + EPS); });
+    }
+
+    // lfo_square
+    #[test]
+    fn square_first_half() { assert!((lfo_square(0.1, 0.5) - 1.0).abs() < EPS); }
+    #[test]
+    fn square_second_half() { assert!((lfo_square(0.6, 0.5) + 1.0).abs() < EPS); }
+    #[test]
+    fn square_narrow_duty() {
+        // 10% duty: phase 0.05 → high, phase 0.15 → low
+        assert!((lfo_square(0.05, 0.1) - 1.0).abs() < EPS);
+        assert!((lfo_square(0.15, 0.1) + 1.0).abs() < EPS);
+    }
+
+    // osc_step
+    #[test]
+    fn osc_phase_advances() {
+        let (_, p1) = osc_step(0.0, 440.0, 44100.0, lfo_sine);
+        assert!((p1 - 440.0 / 44100.0).abs() < EPS);
+    }
+    #[test]
+    fn osc_phase_wraps() {
+        let (_, p1) = osc_step(0.99, 440.0, 44100.0, lfo_sine);
+        assert!(p1 < 1.0);
+    }
+    #[test]
+    fn osc_deterministic() {
+        let (y1, _) = osc_step(0.25, 440.0, 44100.0, lfo_sine);
+        let (y2, _) = osc_step(0.25, 440.0, 44100.0, lfo_sine);
+        assert_eq!(y1, y2);
+    }
+
+    // adsr_step
+    #[test]
+    fn adsr_starts_at_zero() {
+        let params = AdsrParams { attack: 0.1, decay: 0.1, sustain: 0.7, release: 0.2 };
+        let (v, _) = adsr_step(AdsrState::IDLE, &params, false, 0.016);
+        assert!((v).abs() < EPS);
+    }
+    #[test]
+    fn adsr_gate_on_rises() {
+        let params = AdsrParams { attack: 0.1, decay: 0.1, sustain: 0.7, release: 0.2 };
+        let (v, _) = adsr_step(AdsrState::IDLE, &params, true, 0.016);
+        assert!(v > 0.0);
+    }
+    #[test]
+    fn adsr_reaches_sustain() {
+        let params = AdsrParams { attack: 0.01, decay: 0.01, sustain: 0.7, release: 0.2 };
+        let final_state = (0..500).fold(
+            (0.0_f32, AdsrState::IDLE),
+            |(_, s), _| adsr_step(s, &params, true, 0.016),
+        );
+        assert!((final_state.0 - 0.7).abs() < 0.01);
+    }
+    #[test]
+    fn adsr_release_decays_to_zero() {
+        let params = AdsrParams { attack: 0.01, decay: 0.01, sustain: 0.7, release: 0.1 };
+        // Reach sustain first
+        let (_, sustain_state) = (0..200).fold(
+            (0.0_f32, AdsrState::IDLE),
+            |(_, s), _| adsr_step(s, &params, true, 0.016),
+        );
+        // Then release
+        let (v, _) = (0..500).fold(
+            (0.0_f32, sustain_state),
+            |(_, s), _| adsr_step(s, &params, false, 0.016),
+        );
+        assert!(v.abs() < 0.01);
+    }
+}

--- a/packages/prime-osc/package.json
+++ b/packages/prime-osc/package.json
@@ -9,5 +9,9 @@
     "build": "tsc",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/prime-osc/src/__tests__/osc.test.ts
+++ b/packages/prime-osc/src/__tests__/osc.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import {
+  lfoSine,
+  lfoTriangle,
+  lfoSawtooth,
+  lfoSquare,
+  oscStep,
+  adsrStep,
+  ADSR_IDLE,
+} from '../index.js'
+
+const EPS = 1e-5
+
+// ── lfoSine ───────────────────────────────────────────────────────────────────
+
+describe('lfoSine', () => {
+  it('zero phase → 0', () => expect(Math.abs(lfoSine(0))).toBeLessThan(EPS))
+  it('quarter phase → 1', () => expect(Math.abs(lfoSine(0.25) - 1)).toBeLessThan(EPS))
+  it('half phase → 0', () => expect(Math.abs(lfoSine(0.5))).toBeLessThan(EPS))
+  it('three-quarter phase → -1', () => expect(Math.abs(lfoSine(0.75) + 1)).toBeLessThan(EPS))
+  it('range [-1, 1]', () =>
+    Array.from({ length: 1000 }, (_, i) => lfoSine(i / 1000))
+      .forEach(v => {
+        expect(v).toBeGreaterThanOrEqual(-1 - EPS)
+        expect(v).toBeLessThanOrEqual(1 + EPS)
+      }))
+})
+
+// ── lfoTriangle ───────────────────────────────────────────────────────────────
+
+describe('lfoTriangle', () => {
+  it('zero phase → 0', () => expect(Math.abs(lfoTriangle(0))).toBeLessThan(EPS))
+  it('quarter phase → 1', () => expect(Math.abs(lfoTriangle(0.25) - 1)).toBeLessThan(EPS))
+  it('half phase → 0', () => expect(Math.abs(lfoTriangle(0.5))).toBeLessThan(EPS))
+  it('three-quarter phase → -1', () => expect(Math.abs(lfoTriangle(0.75) + 1)).toBeLessThan(EPS))
+  it('range [-1, 1]', () =>
+    Array.from({ length: 1000 }, (_, i) => lfoTriangle(i / 1000))
+      .forEach(v => {
+        expect(v).toBeGreaterThanOrEqual(-1 - EPS)
+        expect(v).toBeLessThanOrEqual(1 + EPS)
+      }))
+})
+
+// ── lfoSawtooth ───────────────────────────────────────────────────────────────
+
+describe('lfoSawtooth', () => {
+  it('zero phase → -1', () => expect(Math.abs(lfoSawtooth(0) + 1)).toBeLessThan(EPS))
+  it('half phase → 0', () => expect(Math.abs(lfoSawtooth(0.5))).toBeLessThan(EPS))
+  it('range [-1, 1]', () =>
+    Array.from({ length: 1000 }, (_, i) => lfoSawtooth(i / 1000))
+      .forEach(v => {
+        expect(v).toBeGreaterThanOrEqual(-1 - EPS)
+        expect(v).toBeLessThanOrEqual(1 + EPS)
+      }))
+  it('monotonically increasing within cycle', () =>
+    Array.from({ length: 99 }, (_, i) => [lfoSawtooth(i / 100), lfoSawtooth((i + 1) / 100)] as [number, number])
+      .forEach(([a, b]) => expect(b).toBeGreaterThan(a - EPS)))
+})
+
+// ── lfoSquare ─────────────────────────────────────────────────────────────────
+
+describe('lfoSquare', () => {
+  it('first half → +1 (50% duty)', () => expect(lfoSquare(0.1, 0.5)).toBe(1))
+  it('second half → -1 (50% duty)', () => expect(lfoSquare(0.6, 0.5)).toBe(-1))
+  it('narrow duty: low at 0.15 when duty=0.1', () => expect(lfoSquare(0.15, 0.1)).toBe(-1))
+  it('only +1 or -1', () =>
+    Array.from({ length: 100 }, (_, i) => lfoSquare(i / 100))
+      .forEach(v => expect(Math.abs(Math.abs(v) - 1)).toBeLessThan(EPS)))
+})
+
+// ── oscStep ───────────────────────────────────────────────────────────────────
+
+describe('oscStep', () => {
+  it('phase advances by freq/sampleRate', () => {
+    const [, p1] = oscStep(0, 440, 44100, lfoSine)
+    expect(Math.abs(p1 - 440 / 44100)).toBeLessThan(EPS)
+  })
+  it('phase stays in [0, 1)', () => {
+    const [, p1] = oscStep(0.99, 440, 44100, lfoSine)
+    expect(p1).toBeGreaterThanOrEqual(0)
+    expect(p1).toBeLessThan(1)
+  })
+  it('deterministic — same inputs same output', () => {
+    const [y1] = oscStep(0.25, 440, 44100, lfoSine)
+    const [y2] = oscStep(0.25, 440, 44100, lfoSine)
+    expect(y1).toBe(y2)
+  })
+  it('threads forward — generates deterministic sequence', () => {
+    const seqA = Array.from({ length: 10 }).reduce(
+      ([samples, p]: [number[], number]) => {
+        const [y, next] = oscStep(p, 440, 44100, lfoSine)
+        return [[...samples, y], next]
+      },
+      [[], 0] as [number[], number],
+    )[0]
+    const seqB = Array.from({ length: 10 }).reduce(
+      ([samples, p]: [number[], number]) => {
+        const [y, next] = oscStep(p, 440, 44100, lfoSine)
+        return [[...samples, y], next]
+      },
+      [[], 0] as [number[], number],
+    )[0]
+    expect(seqA).toEqual(seqB)
+  })
+})
+
+// ── adsrStep ──────────────────────────────────────────────────────────────────
+
+describe('adsrStep', () => {
+  const params = { attack: 0.1, decay: 0.1, sustain: 0.7, release: 0.2 }
+
+  it('idle with gate off → 0', () => {
+    const [v] = adsrStep(ADSR_IDLE, params, false, 0.016)
+    expect(v).toBe(0)
+  })
+
+  it('gate on from idle → value rises', () => {
+    const [v] = adsrStep(ADSR_IDLE, params, true, 0.016)
+    expect(v).toBeGreaterThan(0)
+  })
+
+  it('reaches sustain level after attack + decay', () => {
+    const fastParams = { attack: 0.01, decay: 0.01, sustain: 0.7, release: 0.2 }
+    const [v] = Array.from({ length: 500 }).reduce(
+      ([, s]: [number, typeof ADSR_IDLE]) => adsrStep(s, fastParams, true, 0.016),
+      [0, ADSR_IDLE] as [number, typeof ADSR_IDLE],
+    )
+    expect(Math.abs(v - 0.7)).toBeLessThan(0.01)
+  })
+
+  it('release decays to zero after gate off', () => {
+    const fastParams = { attack: 0.01, decay: 0.01, sustain: 0.7, release: 0.1 }
+    const [, sustainState] = Array.from({ length: 200 }).reduce(
+      ([, s]: [number, typeof ADSR_IDLE]) => adsrStep(s, fastParams, true, 0.016),
+      [0, ADSR_IDLE] as [number, typeof ADSR_IDLE],
+    )
+    const [v] = Array.from({ length: 500 }).reduce(
+      ([, s]: [number, typeof ADSR_IDLE]) => adsrStep(s, fastParams, false, 0.016),
+      [0, sustainState] as [number, typeof ADSR_IDLE],
+    )
+    expect(v).toBeLessThan(0.01)
+  })
+
+  it('does not mutate params or state', () => {
+    const state = { ...ADSR_IDLE }
+    const p = { ...params }
+    adsrStep(state, p, true, 0.016)
+    expect(state).toEqual(ADSR_IDLE)
+    expect(p).toEqual(params)
+  })
+
+  it('deterministic — same inputs same output', () => {
+    const [v1, s1] = adsrStep(ADSR_IDLE, params, true, 0.016)
+    const [v2, s2] = adsrStep(ADSR_IDLE, params, true, 0.016)
+    expect(v1).toBe(v2)
+    expect(s1).toEqual(s2)
+  })
+})

--- a/packages/prime-osc/src/index.ts
+++ b/packages/prime-osc/src/index.ts
@@ -1,2 +1,199 @@
-// TODO: implement
-export {};
+/**
+ * prime-osc — Oscillators and envelopes.
+ *
+ * All public functions are LOAD + COMPUTE. No STORE. No JUMP.
+ * Phase threads forward as an explicit value — same inputs → same output.
+ */
+
+// ── LFO shape functions ──────────────────────────────────────────────────────
+
+/**
+ * Sine wave at normalised phase.
+ *
+ * @param phase - Normalised phase in [0, 1). Wraps automatically.
+ * @returns Value in [-1, 1].
+ *
+ * @example
+ * lfoSine(0.25) // ≈ 1.0 — quarter cycle
+ */
+export const lfoSine = (phase: number): number =>
+  Math.sin(phase * Math.PI * 2)
+
+/**
+ * Triangle wave at normalised phase.
+ *
+ * @remarks
+ *   p = frac(phase),  y = 2 × |2p − 1| − 1
+ *
+ * @param phase - Normalised phase in [0, 1).
+ * @returns Value in [-1, 1]. Peaks at phase=0.25, troughs at phase=0.75.
+ *
+ * @example
+ * lfoTriangle(0.25) // 1.0 — peak
+ */
+export const lfoTriangle = (phase: number): number => {
+  const p = (phase + 0.75) - Math.floor(phase + 0.75)
+  return 2 * Math.abs(2 * p - 1) - 1
+}
+
+/**
+ * Sawtooth wave (rising) at normalised phase.
+ *
+ * @remarks
+ *   y = 2 × frac(phase) − 1
+ *
+ * @param phase - Normalised phase in [0, 1).
+ * @returns Value in [-1, 1).
+ *
+ * @example
+ * lfoSawtooth(0.0) // -1.0 — start of cycle
+ */
+export const lfoSawtooth = (phase: number): number => {
+  const p = phase - Math.floor(phase)
+  return 2 * p - 1
+}
+
+/**
+ * Square wave at normalised phase.
+ *
+ * @remarks
+ *   y = +1 if frac(phase) < width, else -1
+ *
+ * @param phase - Normalised phase in [0, 1).
+ * @param width - Duty cycle in (0, 1). Default 0.5.
+ * @returns Value in {-1, +1}.
+ *
+ * @example
+ * lfoSquare(0.1, 0.5) // 1.0 — first half of cycle
+ */
+export const lfoSquare = (phase: number, width = 0.5): number => {
+  const p = phase - Math.floor(phase)
+  const w = Math.min(0.999, Math.max(0.001, width))
+  return p < w ? 1 : -1
+}
+
+// ── Oscillator step ──────────────────────────────────────────────────────────
+
+/**
+ * Advance oscillator phase by one sample — APPEND pattern.
+ *
+ * @remarks
+ *   new_phase = frac(phase + freq / sampleRate)
+ *   y = shape(new_phase)
+ *
+ * @param phase - Current phase in [0, 1).
+ * @param freq - Frequency in Hz.
+ * @param sampleRate - Sample rate in Hz.
+ * @param shape - Shape function: lfoSine, lfoTriangle, etc.
+ * @returns `[sample, newPhase]` — thread `newPhase` into the next call.
+ *
+ * @example
+ * const [y, p1] = oscStep(0, 440, 44100, lfoSine)
+ * const [y2, p2] = oscStep(p1, 440, 44100, lfoSine)
+ */
+export const oscStep = (
+  phase: number,
+  freq: number,
+  sampleRate: number,
+  shape: (phase: number) => number,
+): [number, number] => {
+  const sr = Math.max(sampleRate, 1)
+  const newPhase = (phase + freq / sr) % 1
+  return [shape(newPhase), newPhase]
+}
+
+// ── ADSR envelope ────────────────────────────────────────────────────────────
+
+/** ADSR stage identifier. */
+export type AdsrStage = 'attack' | 'decay' | 'sustain' | 'release' | 'done'
+
+/** ADSR envelope parameters. All times in seconds. */
+export type AdsrParams = {
+  /** Attack time: 0 → 1 */
+  readonly attack: number
+  /** Decay time: 1 → sustain */
+  readonly decay: number
+  /** Sustain level [0, 1] */
+  readonly sustain: number
+  /** Release time: sustain → 0 */
+  readonly release: number
+}
+
+/** ADSR envelope state. Thread this forward with each call to adsrStep. */
+export type AdsrState = {
+  readonly stage: AdsrStage
+  /** Current envelope value in [0, 1]. */
+  readonly value: number
+  /** Time elapsed in current stage (seconds). */
+  readonly elapsed: number
+}
+
+/** Initial envelope state — at rest. */
+export const ADSR_IDLE: AdsrState = { stage: 'done', value: 0, elapsed: 0 }
+
+/**
+ * Advance ADSR envelope by one time step — pure LOAD + COMPUTE.
+ *
+ * @remarks
+ *   Attack:  value rises 0 → 1 over attack seconds
+ *   Decay:   value falls 1 → sustain over decay seconds
+ *   Sustain: value holds at sustain while gate is on
+ *   Release: value falls from current → 0 over release seconds
+ *   Done:    value = 0
+ *
+ * @param state - Current envelope state.
+ * @param params - ADSR parameters.
+ * @param gate - true = note on, false = note off (trigger release).
+ * @param dt - Delta time in seconds.
+ * @returns `[value, newState]` — thread `newState` forward.
+ *
+ * @example
+ * const params = { attack: 0.1, decay: 0.1, sustain: 0.7, release: 0.2 }
+ * const [v, s1] = adsrStep(ADSR_IDLE, params, true, 0.016)
+ */
+export const adsrStep = (
+  state: AdsrState,
+  params: AdsrParams,
+  gate: boolean,
+  dt: number,
+): [number, AdsrState] => {
+  const attack = Math.max(params.attack, 1e-4)
+  const decay = Math.max(params.decay, 1e-4)
+  const release = Math.max(params.release, 1e-4)
+  const sustain = Math.min(1, Math.max(0, params.sustain))
+
+  if (!gate) {
+    if (state.stage === 'done') return [0, ADSR_IDLE]
+    if (state.stage === 'release') {
+      const t = Math.min(1, state.elapsed / release)
+      const newElapsed = state.elapsed + dt
+      if (newElapsed >= release) return [0, ADSR_IDLE]
+      return [state.value * (1 - t), { stage: 'release', value: state.value, elapsed: newElapsed }]
+    }
+    return [state.value, { stage: 'release', value: state.value, elapsed: 0 }]
+  }
+
+  if (state.stage === 'done' || state.stage === 'release') {
+    const newElapsed = dt
+    const newVal = Math.min(1, newElapsed / attack)
+    if (newElapsed >= attack) return [1, { stage: 'decay', value: 1, elapsed: 0 }]
+    return [newVal, { stage: 'attack', value: newVal, elapsed: newElapsed }]
+  }
+
+  if (state.stage === 'attack') {
+    const newElapsed = state.elapsed + dt
+    const newVal = Math.min(1, newElapsed / attack)
+    if (newElapsed >= attack) return [1, { stage: 'decay', value: 1, elapsed: 0 }]
+    return [newVal, { stage: 'attack', value: newVal, elapsed: newElapsed }]
+  }
+
+  if (state.stage === 'decay') {
+    const newElapsed = state.elapsed + dt
+    const t = Math.min(1, newElapsed / decay)
+    const newVal = 1 + (sustain - 1) * t
+    if (newElapsed >= decay) return [sustain, { stage: 'sustain', value: sustain, elapsed: 0 }]
+    return [newVal, { stage: 'decay', value: newVal, elapsed: newElapsed }]
+  }
+
+  return [sustain, { stage: 'sustain', value: sustain, elapsed: state.elapsed + dt }]
+}

--- a/packages/prime-osc/tsconfig.json
+++ b/packages/prime-osc/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- `lfoSine/lfoTriangle/lfoSawtooth/lfoSquare` — all phase-aligned (peak at 0.25)
- `oscStep(phase, freq, sr, shape) → [sample, newPhase]` — phase threads forward
- `adsrStep(state, params, gate, dt) → [value, newState]` — AdsrState threads forward
- Score now has everything it needs: prime-osc ✓ prime-interp ✓ prime-signal ✓ prime-random ✓
- 23 Rust tests, 28 TS tests

## Stack
Part 5/8 — stacks on `feat/prime-signal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)