### PR TITLE
feat(prime-render): pure sample-level scan loop — ADVANCE evaluator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/prime-voronoi",
     "crates/prime-diffusion",
     "crates/prime-dynamics",
+    "crates/prime-render",
 ]
 resolver = "2"
 

--- a/crates/prime-render/Cargo.toml
+++ b/crates/prime-render/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name        = "prime-render"
+description = "Pure sample-level scan loop — the ADVANCE evaluator for Score's temporal assembly thesis"
+version.workspace    = true
+edition.workspace    = true
+license.workspace    = true
+repository.workspace = true

--- a/crates/prime-render/src/lib.rs
+++ b/crates/prime-render/src/lib.rs
@@ -1,0 +1,352 @@
+//! `prime-render` — Pure sample-level scan loop.
+//!
+//! This is the ADVANCE evaluator for the temporal assembly thesis. A rendered
+//! buffer is the result of folding a pure step function over time:
+//!
+//! ```text
+//! output[n] = f(state_n, t_n)   where   state_{n+1} = step(state_n, t_n).sample_rate
+//! ```
+//!
+//! `render` is the only place in PRIME where ADVANCE is the *explicit* design.
+//! Everything else in PRIME is LOAD + COMPUTE (single-step). Here we fold N steps.
+//!
+//! # Temporal Assembly in PRIME
+//!
+//! ```text
+//! LOAD    ← initial_state, sample_rate, num_samples, step fn
+//! COMPUTE ← fold: (state, sample_index) → (sample, next_state)
+//! APPEND  ← push each sample into the output buffer
+//! ADVANCE ← repeat for every sample — this is the scan loop
+//! ```
+//!
+//! The `step` function is always LOAD + COMPUTE only. It never calls `render`
+//! recursively, never mutates, never reads the clock. Same inputs → same output.
+
+/// Render a mono audio buffer by folding a pure step function over time.
+///
+/// This is the core ADVANCE operation for Score's temporal assembly thesis.
+/// The output is a deterministic function of `initial_state`, `sample_rate`,
+/// and `step` — no hidden state, no I/O, no side effects.
+///
+/// # Math
+///
+/// ```text
+/// dt = 1 / sample_rate
+/// output[n], state_{n+1} = step(state_n, n * dt)
+/// ```
+///
+/// # Arguments
+/// * `initial_state` — starting DSP state (e.g. oscillator phase, envelope stage)
+/// * `sample_rate`   — samples per second (e.g. 44100)
+/// * `num_samples`   — number of output samples to generate
+/// * `step`          — pure function: `(state, time_in_seconds) → (sample, next_state)`
+///
+/// # Returns
+/// `Vec<f32>` of exactly `num_samples` mono samples in [-1.0, 1.0].
+///
+/// # Edge cases
+/// * `num_samples == 0` → returns empty `Vec`
+/// * `sample_rate == 0` → `dt = infinity`; step receives `f64::INFINITY` for t > 0
+///
+/// # Example
+/// ```rust
+/// // Render 4 samples of a 440 Hz sine at 4 Hz (for clarity)
+/// use prime_render::render;
+/// use std::f64::consts::TAU;
+///
+/// let samples = render(0.0_f64, 4, 4, |phase, _t| {
+///     let sample = phase.sin() as f32;
+///     let next = (phase + TAU * 440.0 / 4.0) % TAU;
+///     (sample, next)
+/// });
+/// assert_eq!(samples.len(), 4);
+/// ```
+pub fn render<S>(
+    initial_state: S,
+    sample_rate: u32,
+    num_samples: usize,
+    step: impl Fn(S, f64) -> (f32, S),
+) -> Vec<f32> {
+    let dt = 1.0 / sample_rate as f64;
+    let (_, samples) = (0..num_samples).fold(
+        (initial_state, Vec::with_capacity(num_samples)),
+        |(state, mut buf), n| {
+            let t = n as f64 * dt;
+            let (sample, next_state) = step(state, t);
+            buf.push(sample);
+            (next_state, buf)
+        },
+    );
+    samples
+}
+
+/// Render a stereo audio buffer by folding a pure step function over time.
+///
+/// Identical to [`render`] but the step function produces a `(left, right)`
+/// sample pair per frame. Returns interleaved `[(L0, R0), (L1, R1), ...]`.
+///
+/// # Arguments
+/// * `initial_state` — starting DSP state
+/// * `sample_rate`   — samples per second
+/// * `num_samples`   — number of stereo frames to generate
+/// * `step`          — pure function: `(state, t) → ((left, right), next_state)`
+///
+/// # Returns
+/// `Vec<(f32, f32)>` of `num_samples` stereo frames.
+///
+/// # Example
+/// ```rust
+/// use prime_render::render_stereo;
+///
+/// // Constant stereo frame — left=0.5, right=-0.5
+/// let frames = render_stereo((), 44100, 3, |s, _t| ((0.5, -0.5), s));
+/// assert_eq!(frames, vec![(0.5, -0.5), (0.5, -0.5), (0.5, -0.5)]);
+/// ```
+pub fn render_stereo<S>(
+    initial_state: S,
+    sample_rate: u32,
+    num_samples: usize,
+    step: impl Fn(S, f64) -> ((f32, f32), S),
+) -> Vec<(f32, f32)> {
+    let dt = 1.0 / sample_rate as f64;
+    let (_, frames) = (0..num_samples).fold(
+        (initial_state, Vec::with_capacity(num_samples)),
+        |(state, mut buf), n| {
+            let t = n as f64 * dt;
+            let (frame, next_state) = step(state, t);
+            buf.push(frame);
+            (next_state, buf)
+        },
+    );
+    frames
+}
+
+/// Render a buffer and reduce it to a scalar — useful for envelope integration
+/// and level metering without allocating the full output.
+///
+/// Folds the same scan loop as [`render`] but accumulates into a single value
+/// `A` instead of collecting samples. The `combine` function receives the
+/// running accumulator and each new sample.
+///
+/// # Arguments
+/// * `initial_state` — starting DSP state
+/// * `initial_acc`   — starting accumulator value
+/// * `sample_rate`   — samples per second
+/// * `num_samples`   — number of samples to process
+/// * `step`          — `(state, t) → (sample, next_state)`
+/// * `combine`       — `(acc, sample) → next_acc`
+///
+/// # Returns
+/// Final accumulated value of type `A`.
+///
+/// # Example
+/// ```rust
+/// use prime_render::render_fold;
+///
+/// // Sum all samples from a constant signal of 0.1
+/// let total = render_fold((), 0.0_f32, 44100, 100, |s, _t| (0.1_f32, s), |acc, x| acc + x);
+/// assert!((total - 10.0).abs() < 1e-4);
+/// ```
+pub fn render_fold<S, A>(
+    initial_state: S,
+    initial_acc: A,
+    sample_rate: u32,
+    num_samples: usize,
+    step: impl Fn(S, f64) -> (f32, S),
+    combine: impl Fn(A, f32) -> A,
+) -> A {
+    let dt = 1.0 / sample_rate as f64;
+    let (_, acc) = (0..num_samples).fold(
+        (initial_state, initial_acc),
+        |(state, acc), n| {
+            let t = n as f64 * dt;
+            let (sample, next_state) = step(state, t);
+            (next_state, combine(acc, sample))
+        },
+    );
+    acc
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::TAU;
+
+    const EPSILON: f32 = 1e-5;
+
+    // ── render ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn render_empty() {
+        let out = render(0.0_f64, 44100, 0, |s, _t| (0.0, s));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn render_single_sample() {
+        let out = render(0.0_f64, 44100, 1, |s, _t| (0.5_f32, s));
+        assert_eq!(out.len(), 1);
+        assert!((out[0] - 0.5).abs() < EPSILON);
+    }
+
+    #[test]
+    fn render_constant_signal() {
+        let out = render((), 44100, 100, |s, _t| (0.25_f32, s));
+        assert_eq!(out.len(), 100);
+        assert!(out.iter().all(|&x| (x - 0.25).abs() < EPSILON));
+    }
+
+    #[test]
+    fn render_correct_length() {
+        let n = 512;
+        let out = render(0_u32, 44100, n, |s, _t| (0.0, s + 1));
+        assert_eq!(out.len(), n);
+    }
+
+    #[test]
+    fn render_threads_state_forward() {
+        // State should accumulate: output[n] should equal n as f32
+        let out = render(0_u32, 44100, 5, |count, _t| (count as f32, count + 1));
+        assert_eq!(out, vec![0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn render_time_argument_correct() {
+        // At sr=10, dt=0.1: t[0]=0.0, t[1]=0.1, t[2]=0.2 ...
+        let out = render((), 10, 4, |s, t| (t as f32, s));
+        assert!((out[0] - 0.0).abs() < EPSILON);
+        assert!((out[1] - 0.1).abs() < EPSILON);
+        assert!((out[2] - 0.2).abs() < EPSILON);
+        assert!((out[3] - 0.3).abs() < EPSILON);
+    }
+
+    #[test]
+    fn render_deterministic() {
+        let step = |phase: f64, _t: f64| {
+            let s = phase.sin() as f32;
+            let next = (phase + TAU * 440.0 / 44100.0) % TAU;
+            (s, next)
+        };
+        let a = render(0.0_f64, 44100, 64, step);
+        let b = render(0.0_f64, 44100, 64, step);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn render_sine_440hz_peak() {
+        // 440 Hz at 44100 sr — peak should be close to 1.0 somewhere in first period
+        let out = render(0.0_f64, 44100, 200, |phase, _t| {
+            let s = phase.sin() as f32;
+            let next = (phase + TAU * 440.0 / 44100.0) % TAU;
+            (s, next)
+        });
+        let peak = out.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(peak > 0.99, "peak={}", peak);
+    }
+
+    #[test]
+    fn render_no_mutation_of_input_state() {
+        let initial = 42_u32;
+        render(initial, 44100, 10, |s, _t| (0.0, s + 1));
+        // initial is Copy — verify it was not mutated (it can't be in Rust, but
+        // this confirms the API takes ownership and threads state correctly)
+        assert_eq!(initial, 42);
+    }
+
+    // ── render_stereo ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn render_stereo_empty() {
+        let out = render_stereo((), 44100, 0, |s, _t| ((0.0, 0.0), s));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn render_stereo_constant() {
+        let out = render_stereo((), 44100, 4, |s, _t| ((0.5_f32, -0.5_f32), s));
+        assert_eq!(out.len(), 4);
+        assert!(out.iter().all(|&(l, r)| (l - 0.5).abs() < EPSILON && (r + 0.5).abs() < EPSILON));
+    }
+
+    #[test]
+    fn render_stereo_threads_state() {
+        let out = render_stereo(0_i32, 44100, 3, |n, _t| ((n as f32, -(n as f32)), n + 1));
+        assert_eq!(out, vec![(0.0, 0.0), (1.0, -1.0), (2.0, -2.0)]);
+    }
+
+    #[test]
+    fn render_stereo_deterministic() {
+        let step = |phase: f64, _t: f64| {
+            let l = phase.sin() as f32;
+            let r = (phase + std::f64::consts::FRAC_PI_2).sin() as f32;
+            let next = (phase + TAU * 440.0 / 44100.0) % TAU;
+            ((l, r), next)
+        };
+        let a = render_stereo(0.0_f64, 44100, 32, step);
+        let b = render_stereo(0.0_f64, 44100, 32, step);
+        assert_eq!(a, b);
+    }
+
+    // ── render_fold ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn render_fold_sum() {
+        // 100 samples of 0.1 → sum = 10.0
+        let total = render_fold((), 0.0_f32, 44100, 100,
+            |s, _t| (0.1_f32, s),
+            |acc, x| acc + x,
+        );
+        assert!((total - 10.0).abs() < 1e-3, "total={}", total);
+    }
+
+    #[test]
+    fn render_fold_max() {
+        let step = |phase: f64, _t: f64| {
+            let s = phase.sin() as f32;
+            let next = (phase + TAU * 440.0 / 44100.0) % TAU;
+            (s, next)
+        };
+        let peak = render_fold(0.0_f64, f32::NEG_INFINITY, 44100, 200, step,
+            f32::max,
+        );
+        assert!(peak > 0.99, "peak={}", peak);
+    }
+
+    #[test]
+    fn render_fold_count() {
+        let count = render_fold((), 0_usize, 44100, 77,
+            |s, _t| (0.0, s),
+            |acc, _x| acc + 1,
+        );
+        assert_eq!(count, 77);
+    }
+
+    #[test]
+    fn render_fold_deterministic() {
+        let step = |phase: f64, _t: f64| {
+            let s = phase.sin() as f32;
+            let next = (phase + TAU / 10.0) % TAU;
+            (s, next)
+        };
+        let a = render_fold(0.0_f64, 0.0_f32, 44100, 50, step, |acc, x| acc + x);
+        let b = render_fold(0.0_f64, 0.0_f32, 44100, 50, step, |acc, x| acc + x);
+        assert!((a - b).abs() < EPSILON);
+    }
+
+    // ── render + osc integration ──────────────────────────────────────────────
+
+    #[test]
+    fn render_integrates_with_tuple_state() {
+        // Multi-field state as a tuple — (phase, amplitude)
+        let out = render((0.0_f64, 1.0_f32), 44100, 4, |(phase, amp), _t| {
+            let s = (phase.sin() as f32) * amp;
+            let next_phase = (phase + TAU * 440.0 / 44100.0) % TAU;
+            let next_amp = amp * 0.999;
+            (s, (next_phase, next_amp))
+        });
+        assert_eq!(out.len(), 4);
+        assert!(out.iter().all(|x| x.abs() <= 1.0));
+    }
+}

--- a/packages/prime-render/package.json
+++ b/packages/prime-render/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@prime/prime-render",
+  "version": "0.1.0",
+  "description": "Pure sample-level scan loop — the ADVANCE evaluator for the temporal assembly thesis",
+  "license": "MIT",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/prime-render/src/__tests__/render.test.ts
+++ b/packages/prime-render/src/__tests__/render.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import { render, renderStereo, renderFold } from '../index.js'
+
+const TAU = Math.PI * 2
+const EPS = 1e-5
+
+// ── render ────────────────────────────────────────────────────────────────────
+
+describe('render', () => {
+  it('empty — numSamples=0 returns []', () => {
+    expect(render(0, 44100, 0, (s, _t) => [0, s])).toEqual([])
+  })
+
+  it('single sample', () => {
+    const [x] = render(0, 44100, 1, (_s, _t) => [0.5, 0])
+    expect(x).toBeCloseTo(0.5, 5)
+  })
+
+  it('correct length', () => {
+    expect(render(0, 44100, 512, (s, _t) => [0, s])).toHaveLength(512)
+  })
+
+  it('constant signal — all samples equal', () => {
+    const out = render(0, 44100, 100, (s, _t) => [0.25, s])
+    expect(out.every(x => Math.abs(x - 0.25) < EPS)).toBe(true)
+  })
+
+  it('threads state forward', () => {
+    // output[n] = n (state counts up)
+    const out = render(0, 44100, 5, (count, _t) => [count, count + 1])
+    expect(out).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('time argument is correct — t[n] = n / sampleRate', () => {
+    const out = render(0, 10, 4, (_s, t) => [t, 0])
+    expect(out[0]).toBeCloseTo(0.0, 5)
+    expect(out[1]).toBeCloseTo(0.1, 5)
+    expect(out[2]).toBeCloseTo(0.2, 5)
+    expect(out[3]).toBeCloseTo(0.3, 5)
+  })
+
+  it('deterministic — same inputs produce same output', () => {
+    const step = (phase: number, _t: number): [number, number] => [
+      Math.sin(phase),
+      (phase + TAU * 440 / 44100) % TAU,
+    ]
+    const a = render(0, 44100, 64, step)
+    const b = render(0, 44100, 64, step)
+    expect(a).toEqual(b)
+  })
+
+  it('440 Hz sine reaches peak near 1.0', () => {
+    const out = render(0, 44100, 200, (phase, _t) => [
+      Math.sin(phase),
+      (phase + TAU * 440 / 44100) % TAU,
+    ])
+    const peak = Math.max(...out)
+    expect(peak).toBeGreaterThan(0.99)
+  })
+
+  it('tuple state — (phase, amplitude)', () => {
+    const out = render([0, 1] as [number, number], 44100, 4, ([phase, amp], _t) => [
+      Math.sin(phase) * amp,
+      [(phase + TAU * 440 / 44100) % TAU, amp * 0.999] as [number, number],
+    ])
+    expect(out).toHaveLength(4)
+    expect(out.every(x => Math.abs(x) <= 1)).toBe(true)
+  })
+
+  it('cross-language parity — matches Rust render output', () => {
+    // Rust: render(0.0_f64, 10, 4, |s, _t| (s as f32, s + 1.0))
+    // output: [0.0, 1.0, 2.0, 3.0]
+    const out = render(0, 10, 4, (s, _t) => [s, s + 1])
+    expect(out[0]).toBeCloseTo(0, 5)
+    expect(out[1]).toBeCloseTo(1, 5)
+    expect(out[2]).toBeCloseTo(2, 5)
+    expect(out[3]).toBeCloseTo(3, 5)
+  })
+})
+
+// ── renderStereo ──────────────────────────────────────────────────────────────
+
+describe('renderStereo', () => {
+  it('empty — returns []', () => {
+    expect(renderStereo(0, 44100, 0, (s, _t) => [[0, 0], s])).toEqual([])
+  })
+
+  it('correct length', () => {
+    expect(renderStereo(0, 44100, 8, (s, _t) => [[0, 0], s])).toHaveLength(8)
+  })
+
+  it('constant stereo — all frames equal', () => {
+    const frames = renderStereo(0, 44100, 4, (s, _t) => [[0.5, -0.5], s])
+    expect(frames.every(([l, r]) => Math.abs(l - 0.5) < EPS && Math.abs(r + 0.5) < EPS)).toBe(true)
+  })
+
+  it('threads state forward', () => {
+    const frames = renderStereo(0, 44100, 3, (n, _t): [[number, number], number] => [[n, -n], n + 1])
+    expect(frames[0][0]).toBeCloseTo(0, 5)
+    expect(frames[0][1]).toBeCloseTo(0, 5)
+    expect(frames[1]).toEqual([1, -1])
+    expect(frames[2]).toEqual([2, -2])
+  })
+
+  it('deterministic', () => {
+    const step = (phase: number, _t: number): [[number, number], number] => [
+      [Math.sin(phase), Math.cos(phase)],
+      (phase + TAU * 440 / 44100) % TAU,
+    ]
+    const a = renderStereo(0, 44100, 32, step)
+    const b = renderStereo(0, 44100, 32, step)
+    expect(a).toEqual(b)
+  })
+
+  it('left and right channels are independent', () => {
+    const frames = renderStereo(0, 44100, 4, (n, _t): [[number, number], number] => [
+      [n * 0.1, n * -0.2],
+      n + 1,
+    ])
+    const lefts = frames.map(([l]) => l)
+    const rights = frames.map(([, r]) => r)
+    expect(lefts[0]).toBeCloseTo(0, 5)
+    expect(lefts[1]).toBeCloseTo(0.1, 5)
+    expect(lefts[2]).toBeCloseTo(0.2, 5)
+    expect(lefts[3]).toBeCloseTo(0.3, 5)
+    expect(rights[0]).toBeCloseTo(0, 5)
+    expect(rights[1]).toBeCloseTo(-0.2, 5)
+  })
+})
+
+// ── renderFold ────────────────────────────────────────────────────────────────
+
+describe('renderFold', () => {
+  it('sum of constant signal', () => {
+    const total = renderFold(0, 0, 44100, 100,
+      (s, _t) => [0.1, s],
+      (acc, x) => acc + x,
+    )
+    expect(total).toBeCloseTo(10.0, 2)
+  })
+
+  it('peak of sine wave', () => {
+    const peak = renderFold(0, -Infinity, 44100, 200,
+      (phase, _t) => [Math.sin(phase), (phase + TAU * 440 / 44100) % TAU],
+      (acc, x) => Math.max(acc, x),
+    )
+    expect(peak).toBeGreaterThan(0.99)
+  })
+
+  it('count equals numSamples', () => {
+    const count = renderFold(0, 0, 44100, 77,
+      (s, _t) => [0, s],
+      (acc) => acc + 1,
+    )
+    expect(count).toBe(77)
+  })
+
+  it('deterministic', () => {
+    const step = (phase: number, _t: number): [number, number] => [
+      Math.sin(phase),
+      (phase + TAU / 10) % TAU,
+    ]
+    const a = renderFold(0, 0, 44100, 50, step, (acc, x) => acc + x)
+    const b = renderFold(0, 0, 44100, 50, step, (acc, x) => acc + x)
+    expect(Math.abs(a - b)).toBeLessThan(EPS)
+  })
+
+  it('max-fold matches max of render output', () => {
+    const step = (phase: number, _t: number): [number, number] => [
+      Math.sin(phase),
+      (phase + TAU * 220 / 44100) % TAU,
+    ]
+    const foldMax = renderFold(0, -Infinity, 44100, 100, step, Math.max)
+    const renderMax = Math.max(...render(0, 44100, 100, step))
+    expect(Math.abs(foldMax - renderMax)).toBeLessThan(EPS)
+  })
+})

--- a/packages/prime-render/src/index.ts
+++ b/packages/prime-render/src/index.ts
@@ -1,0 +1,135 @@
+/**
+ * prime-render — Pure sample-level scan loop.
+ *
+ * This is the ADVANCE evaluator for the temporal assembly thesis. A rendered
+ * buffer is the result of folding a pure step function over time:
+ *
+ *   output[n] = f(state_n, t_n)   where   state_{n+1} = step(state_n, t_n).sampleRate
+ *
+ * `render` is the only place in PRIME where ADVANCE is the *explicit* design.
+ * Everything else in PRIME is LOAD + COMPUTE (single-step). Here we fold N steps.
+ *
+ * Temporal assembly:
+ *   LOAD    ← initialState, sampleRate, numSamples, step fn
+ *   COMPUTE ← fold: (state, n) → (sample, nextState)
+ *   APPEND  ← collect each sample into output
+ *   ADVANCE ← repeat for every sample — this is the scan loop
+ *
+ * All exported functions are pure (LOAD + COMPUTE + ADVANCE only).
+ * No mutation, no side effects, no hidden state. Zero `let`.
+ */
+
+/**
+ * Render a mono audio buffer by folding a pure step function over time.
+ *
+ * The output is a deterministic function of `initialState`, `sampleRate`,
+ * and `step` — no hidden state, no I/O, no side effects.
+ *
+ * Math:
+ *   dt = 1 / sampleRate
+ *   output[n], state_{n+1} = step(state_n, n * dt)
+ *
+ * @param initialState  - Starting DSP state (oscillator phase, envelope stage, etc.)
+ * @param sampleRate    - Samples per second (e.g. 44100)
+ * @param numSamples    - Number of output samples to generate
+ * @param step          - Pure function: `(state, timeInSeconds) → [sample, nextState]`
+ * @returns             - Array of `numSamples` mono samples
+ *
+ * @example
+ * // Render 4 samples of a 440 Hz sine at 44100 sr
+ * const TAU = Math.PI * 2
+ * const samples = render(0, 44100, 4, (phase, _t) => [
+ *   Math.sin(phase),
+ *   (phase + TAU * 440 / 44100) % TAU,
+ * ])
+ */
+export const render = <S>(
+  initialState: S,
+  sampleRate: number,
+  numSamples: number,
+  step: (state: S, t: number) => [number, S],
+): number[] => {
+  const dt = 1 / sampleRate
+  const [, , samples] = Array.from<null>({ length: numSamples }).reduce(
+    ([state, n, buf]: [S, number, number[]]): [S, number, number[]] => {
+      const [sample, nextState] = step(state, n * dt)
+      return [nextState, n + 1, [...buf, sample]]
+    },
+    [initialState, 0, []] as [S, number, number[]],
+  )
+  return samples
+}
+
+/**
+ * Render a stereo audio buffer by folding a pure step function over time.
+ *
+ * Identical to `render` but the step function produces a `[left, right]`
+ * sample pair per frame.
+ *
+ * @param initialState  - Starting DSP state
+ * @param sampleRate    - Samples per second
+ * @param numSamples    - Number of stereo frames to generate
+ * @param step          - Pure function: `(state, t) → [[left, right], nextState]`
+ * @returns             - Array of `[left, right]` stereo frame pairs
+ *
+ * @example
+ * const frames = renderStereo(0, 44100, 3, (phase, _t) => [
+ *   [Math.sin(phase), Math.cos(phase)],
+ *   (phase + Math.PI * 2 * 440 / 44100) % (Math.PI * 2),
+ * ])
+ */
+export const renderStereo = <S>(
+  initialState: S,
+  sampleRate: number,
+  numSamples: number,
+  step: (state: S, t: number) => [[number, number], S],
+): [number, number][] => {
+  const dt = 1 / sampleRate
+  const [, , frames] = Array.from<null>({ length: numSamples }).reduce(
+    ([state, n, buf]: [S, number, [number, number][]]): [S, number, [number, number][]] => {
+      const [frame, nextState] = step(state, n * dt)
+      return [nextState, n + 1, [...buf, frame]]
+    },
+    [initialState, 0, []] as [S, number, [number, number][]],
+  )
+  return frames
+}
+
+/**
+ * Render a buffer and reduce it to a scalar — useful for envelope integration
+ * and level metering without allocating the full output array.
+ *
+ * @param initialState  - Starting DSP state
+ * @param initialAcc    - Starting accumulator value
+ * @param sampleRate    - Samples per second
+ * @param numSamples    - Number of samples to process
+ * @param step          - `(state, t) → [sample, nextState]`
+ * @param combine       - `(acc, sample) → nextAcc`
+ * @returns             - Final accumulated value
+ *
+ * @example
+ * // Sum all samples from a constant signal of 0.1
+ * const total = renderFold(null, 0, 44100, 100,
+ *   (_s, _t) => [0.1, null],
+ *   (acc, x) => acc + x,
+ * )
+ * // total ≈ 10.0
+ */
+export const renderFold = <S, A>(
+  initialState: S,
+  initialAcc: A,
+  sampleRate: number,
+  numSamples: number,
+  step: (state: S, t: number) => [number, S],
+  combine: (acc: A, sample: number) => A,
+): A => {
+  const dt = 1 / sampleRate
+  const [, , acc] = Array.from<null>({ length: numSamples }).reduce(
+    ([state, n, acc]: [S, number, A]): [S, number, A] => {
+      const [sample, nextState] = step(state, n * dt)
+      return [nextState, n + 1, combine(acc, sample)]
+    },
+    [initialState, 0, initialAcc] as [S, number, A],
+  )
+  return acc
+}

--- a/packages/prime-render/tsconfig.json
+++ b/packages/prime-render/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,15 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1
 
+  packages/prime-render:
+    devDependencies:
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1
+
   packages/prime-sdf:
     devDependencies:
       typescript:
@@ -104,24 +113,6 @@ importers:
       vitest:
         specifier: ^1.6.0
         version: 1.6.1
-
-  packages/stage-ai: {}
-
-  packages/stage-combat: {}
-
-  packages/stage-economy: {}
-
-  packages/stage-input: {}
-
-  packages/stage-loop: {}
-
-  packages/stage-nav: {}
-
-  packages/stage-proc: {}
-
-  packages/stage-quest: {}
-
-  packages/stage-world: {}
 
 packages:
 


### PR DESCRIPTION
## Summary

- Adds `prime-render` crate + TypeScript package — the ADVANCE evaluator for the temporal assembly thesis
- `render<S>` folds a pure `step(state, t) → (sample, nextState)` function over N samples
- `render_stereo<S>` stereo variant returning `(f32, f32)` frames
- `render_fold<S,A>` scan + reduce to scalar (peak meter, RMS, sum)
- 18 Rust tests + 21 TypeScript tests, clippy clean
- Stacked on `chore/remove-stage-crates` (PR #10)

## Why this matters

This is the crate Score needs for `muteEnvelope(bar)` (t116) and the full thesis proof that `output[n] = f(song, n, sr)` — a song is a pure function of time, evaluated at the sample level. Without a scan loop, the thesis is incomplete at the DSP layer.

## Test plan

- [x] `cargo test -p prime-render` — 18 tests pass
- [x] `cargo clippy -p prime-render -- -D warnings` — clean
- [x] `pnpm run typecheck` in prime-render package — clean
- [x] `pnpm run test` in prime-render package — 21 tests pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)