### PR TITLE
feat(prime-noise): 3D noise, simplex, and domain warping

### DIFF
--- a/crates/prime-noise/src/lib.rs
+++ b/crates/prime-noise/src/lib.rs
@@ -1,4 +1,4 @@
-//! prime-noise — Noise functions: value noise, Perlin, FBM, Worley.
+//! prime-noise — Noise functions: value noise, Perlin, FBM, Worley, Simplex, domain warp.
 //!
 //! All public functions are pure (LOAD + COMPUTE only). No `&mut`, no side effects,
 //! no hidden state. Same inputs always produce the same output.
@@ -357,6 +357,428 @@ pub fn worley_2d(x: f32, y: f32, seed: u32) -> f32 {
 }
 
 // ---------------------------------------------------------------------------
+// 3D internal helpers
+// ---------------------------------------------------------------------------
+
+/// Hash a 3-D integer lattice coordinate to a `f32` in [0, 1].
+#[inline(always)]
+fn hash_3d(xi: i32, yi: i32, zi: i32) -> f32 {
+    let h = hash_u32(
+        hash_u32(hash_u32(xi as u32).wrapping_add(yi as u32)).wrapping_add(zi as u32),
+    );
+    (h as f32) / (u32::MAX as f32)
+}
+
+/// Twelve gradient vectors: midpoints of the edges of a unit cube.
+///
+/// Used by `perlin_3d` and `simplex_3d`.
+const GRADIENTS_3D: [(f32, f32, f32); 12] = [
+    (1.0, 1.0, 0.0),
+    (-1.0, 1.0, 0.0),
+    (1.0, -1.0, 0.0),
+    (-1.0, -1.0, 0.0),
+    (1.0, 0.0, 1.0),
+    (-1.0, 0.0, 1.0),
+    (1.0, 0.0, -1.0),
+    (-1.0, 0.0, -1.0),
+    (0.0, 1.0, 1.0),
+    (0.0, -1.0, 1.0),
+    (0.0, 1.0, -1.0),
+    (0.0, -1.0, -1.0),
+];
+
+/// Map a lattice hash in [0, 1] to one of the twelve 3-D gradient vectors.
+#[inline(always)]
+fn gradient_3d(h: f32) -> (f32, f32, f32) {
+    GRADIENTS_3D[(h * 12.0) as usize % 12]
+}
+
+/// Dot product of a 3-D gradient with offset `(dx, dy, dz)`.
+#[inline(always)]
+fn grad_dot_3d(g: (f32, f32, f32), dx: f32, dy: f32, dz: f32) -> f32 {
+    g.0 * dx + g.1 * dy + g.2 * dz
+}
+
+// ---------------------------------------------------------------------------
+// 3-D value noise
+// ---------------------------------------------------------------------------
+
+/// Smooth value noise at a 3-D point.
+///
+/// # Math
+///
+/// ```text
+/// xi = floor(x), yi = floor(y), zi = floor(z)
+/// fx = fract(x), fy = fract(y), fz = fract(z)
+/// tx = smoothstep(fx), ty = smoothstep(fy), tz = smoothstep(fz)
+///
+/// Trilinear interpolation over the 8 lattice corners.
+/// result ∈ [0, 1]
+/// ```
+///
+/// # Arguments
+/// * `x` — x coordinate (any finite `f32`)
+/// * `y` — y coordinate (any finite `f32`)
+/// * `z` — z coordinate (any finite `f32`)
+///
+/// # Returns
+/// A value in [0, 1].
+///
+/// # Example
+/// ```rust
+/// use prime_noise::value_noise_3d;
+/// let v = value_noise_3d(1.5, 2.3, 0.7);
+/// assert!(v >= 0.0 && v <= 1.0);
+/// ```
+pub fn value_noise_3d(x: f32, y: f32, z: f32) -> f32 {
+    let xi = x.floor() as i32;
+    let yi = y.floor() as i32;
+    let zi = z.floor() as i32;
+    let fx = x - x.floor();
+    let fy = y - y.floor();
+    let fz = z - z.floor();
+
+    let tx = smoothstep(fx);
+    let ty = smoothstep(fy);
+    let tz = smoothstep(fz);
+
+    let v000 = hash_3d(xi,     yi,     zi    );
+    let v100 = hash_3d(xi + 1, yi,     zi    );
+    let v010 = hash_3d(xi,     yi + 1, zi    );
+    let v110 = hash_3d(xi + 1, yi + 1, zi    );
+    let v001 = hash_3d(xi,     yi,     zi + 1);
+    let v101 = hash_3d(xi + 1, yi,     zi + 1);
+    let v011 = hash_3d(xi,     yi + 1, zi + 1);
+    let v111 = hash_3d(xi + 1, yi + 1, zi + 1);
+
+    let bot = lerp(lerp(v000, v100, tx), lerp(v010, v110, tx), ty);
+    let top = lerp(lerp(v001, v101, tx), lerp(v011, v111, tx), ty);
+    lerp(bot, top, tz)
+}
+
+// ---------------------------------------------------------------------------
+// 3-D Perlin noise
+// ---------------------------------------------------------------------------
+
+/// Classic Perlin gradient noise at a 3-D point.
+///
+/// # Math
+///
+/// ```text
+/// 8-corner trilinear blend of gradient dot products.
+/// result ∈ approximately [-1, 1] (exact bounds not guaranteed).
+/// At integer lattice points: result = 0.
+/// ```
+///
+/// # Arguments
+/// * `x`, `y`, `z` — coordinates (any finite `f32`)
+///
+/// # Returns
+/// Approximately in [-1, 1]. Not clamped.
+///
+/// # Edge cases
+/// * At integer lattice points all offsets are 0, so all gradient dot products
+///   are 0 and the result is 0.0.
+///
+/// # Example
+/// ```rust
+/// use prime_noise::perlin_3d;
+/// let v = perlin_3d(0.5, 0.5, 0.5);
+/// assert!(v >= -1.5 && v <= 1.5);
+/// assert_eq!(perlin_3d(1.0, 2.0, 3.0), 0.0);
+/// ```
+pub fn perlin_3d(x: f32, y: f32, z: f32) -> f32 {
+    let xi = x.floor() as i32;
+    let yi = y.floor() as i32;
+    let zi = z.floor() as i32;
+    let fx = x - x.floor();
+    let fy = y - y.floor();
+    let fz = z - z.floor();
+
+    let tx = smoothstep(fx);
+    let ty = smoothstep(fy);
+    let tz = smoothstep(fz);
+
+    let g000 = gradient_3d(hash_3d(xi,     yi,     zi    ));
+    let g100 = gradient_3d(hash_3d(xi + 1, yi,     zi    ));
+    let g010 = gradient_3d(hash_3d(xi,     yi + 1, zi    ));
+    let g110 = gradient_3d(hash_3d(xi + 1, yi + 1, zi    ));
+    let g001 = gradient_3d(hash_3d(xi,     yi,     zi + 1));
+    let g101 = gradient_3d(hash_3d(xi + 1, yi,     zi + 1));
+    let g011 = gradient_3d(hash_3d(xi,     yi + 1, zi + 1));
+    let g111 = gradient_3d(hash_3d(xi + 1, yi + 1, zi + 1));
+
+    let n000 = grad_dot_3d(g000, fx,       fy,       fz      );
+    let n100 = grad_dot_3d(g100, fx - 1.0, fy,       fz      );
+    let n010 = grad_dot_3d(g010, fx,       fy - 1.0, fz      );
+    let n110 = grad_dot_3d(g110, fx - 1.0, fy - 1.0, fz      );
+    let n001 = grad_dot_3d(g001, fx,       fy,       fz - 1.0);
+    let n101 = grad_dot_3d(g101, fx - 1.0, fy,       fz - 1.0);
+    let n011 = grad_dot_3d(g011, fx,       fy - 1.0, fz - 1.0);
+    let n111 = grad_dot_3d(g111, fx - 1.0, fy - 1.0, fz - 1.0);
+
+    let bot = lerp(lerp(n000, n100, tx), lerp(n010, n110, tx), ty);
+    let top = lerp(lerp(n001, n101, tx), lerp(n011, n111, tx), ty);
+    lerp(bot, top, tz)
+}
+
+/// Fractional Brownian Motion over 3-D Perlin noise.
+///
+/// # Math
+///
+/// ```text
+/// result = Σ_{i=0}^{octaves-1} amplitude_i * perlin_3d(x*freq_i, y*freq_i, z*freq_i)
+/// ```
+///
+/// # Arguments
+/// * `x`, `y`, `z` — coordinates
+/// * `octaves`     — number of noise layers (0 returns 0.0)
+/// * `lacunarity`  — frequency multiplier per octave (typically 2.0)
+/// * `gain`        — amplitude multiplier per octave (typically 0.5)
+///
+/// # Returns
+/// Sum of octave contributions. Not clamped.
+///
+/// # Example
+/// ```rust
+/// use prime_noise::fbm_3d;
+/// let v = fbm_3d(0.3, 0.7, 0.2, 6, 2.0, 0.5);
+/// assert!(v.abs() < 3.0);
+/// ```
+pub fn fbm_3d(x: f32, y: f32, z: f32, octaves: u32, lacunarity: f32, gain: f32) -> f32 {
+    let (value, _, _) = (0..octaves).fold((0.0_f32, 1.0_f32, 1.0_f32), |(acc, freq, amp), _| {
+        (acc + amp * perlin_3d(x * freq, y * freq, z * freq), freq * lacunarity, amp * gain)
+    });
+    value
+}
+
+// ---------------------------------------------------------------------------
+// Simplex noise (2-D and 3-D)
+// ---------------------------------------------------------------------------
+
+// Skew / unskew constants (computed from known surds to avoid precision lint).
+// F2 = (sqrt(3) - 1) / 2
+const SIMPLEX_F2: f32 = 0.366_025_4; // (sqrt(3)-1)/2
+// G2 = (3 - sqrt(3)) / 6
+const SIMPLEX_G2: f32 = 0.211_324_87; // (3-sqrt(3))/6
+// F3 = 1/3
+const SIMPLEX_F3: f32 = 1.0 / 3.0;
+// G3 = 1/6
+const SIMPLEX_G3: f32 = 1.0 / 6.0;
+
+/// Simplex noise at a 2-D point.
+///
+/// Uses triangular (simplex) instead of square lattice cells — no directional
+/// artifacts and fewer corners to evaluate (3 vs. 4) compared to Perlin.
+///
+/// # Math
+///
+/// ```text
+/// Skew (x,y) into a square lattice, locate the triangle (simplex) containing
+/// the point, evaluate radial-falloff gradient contributions from the 3 corners,
+/// scale so the result is approximately in [-1, 1].
+/// ```
+///
+/// # Arguments
+/// * `x`, `y` — coordinates (any finite `f32`)
+///
+/// # Returns
+/// Approximately in [-1, 1]. Not clamped.
+///
+/// # Edge cases
+/// * Returns 0.0 at the origin.
+///
+/// # Example
+/// ```rust
+/// use prime_noise::simplex_2d;
+/// let v = simplex_2d(0.5, 0.5);
+/// assert!(v >= -1.1 && v <= 1.1);
+/// ```
+pub fn simplex_2d(x: f32, y: f32) -> f32 {
+    let s = (x + y) * SIMPLEX_F2;
+    let i = (x + s).floor() as i32;
+    let j = (y + s).floor() as i32;
+
+    let t = (i + j) as f32 * SIMPLEX_G2;
+    let x0 = x - (i as f32 - t);
+    let y0 = y - (j as f32 - t);
+
+    // Which triangle?
+    let (i1, j1) = if x0 > y0 { (1_i32, 0_i32) } else { (0_i32, 1_i32) };
+
+    let x1 = x0 - i1 as f32 + SIMPLEX_G2;
+    let y1 = y0 - j1 as f32 + SIMPLEX_G2;
+    let x2 = x0 - 1.0 + 2.0 * SIMPLEX_G2;
+    let y2 = y0 - 1.0 + 2.0 * SIMPLEX_G2;
+
+    let contrib = |xi: i32, yi: i32, dx: f32, dy: f32| -> f32 {
+        let t = 0.5 - dx * dx - dy * dy;
+        if t < 0.0 {
+            0.0
+        } else {
+            let t2 = t * t;
+            t2 * t2 * grad_dot(gradient(hash_2d(xi, yi)), dx, dy)
+        }
+    };
+
+    70.0 * (contrib(i, j, x0, y0) + contrib(i + i1, j + j1, x1, y1) + contrib(i + 1, j + 1, x2, y2))
+}
+
+/// Simplex noise at a 3-D point.
+///
+/// Evaluates 4 tetrahedral corners instead of 8 cubic corners, reducing
+/// the per-sample cost compared to 3-D Perlin while eliminating grid artifacts.
+///
+/// # Math
+///
+/// ```text
+/// Skew (x,y,z) into a cubic lattice via F3=1/3 factor.
+/// Locate which tetrahedron (simplex) contains the point.
+/// Sum radial-falloff gradient contributions from the 4 corners.
+/// Scale to approximately [-1, 1].
+/// ```
+///
+/// # Arguments
+/// * `x`, `y`, `z` — coordinates (any finite `f32`)
+///
+/// # Returns
+/// Approximately in [-1, 1]. Not clamped.
+///
+/// # Example
+/// ```rust
+/// use prime_noise::simplex_3d;
+/// let v = simplex_3d(0.5, 0.5, 0.5);
+/// assert!(v >= -1.1 && v <= 1.1);
+/// ```
+pub fn simplex_3d(x: f32, y: f32, z: f32) -> f32 {
+    let s = (x + y + z) * SIMPLEX_F3;
+    let i = (x + s).floor() as i32;
+    let j = (y + s).floor() as i32;
+    let k = (z + s).floor() as i32;
+
+    let t = (i + j + k) as f32 * SIMPLEX_G3;
+    let x0 = x - (i as f32 - t);
+    let y0 = y - (j as f32 - t);
+    let z0 = z - (k as f32 - t);
+
+    // Which tetrahedron?
+    let (i1, j1, k1, i2, j2, k2) = if x0 >= y0 {
+        if y0 >= z0      { (1, 0, 0,  1, 1, 0) }
+        else if x0 >= z0 { (1, 0, 0,  1, 0, 1) }
+        else             { (0, 0, 1,  1, 0, 1) }
+    } else {
+        if y0 < z0       { (0, 0, 1,  0, 1, 1) }
+        else if x0 < z0  { (0, 1, 0,  0, 1, 1) }
+        else             { (0, 1, 0,  1, 1, 0) }
+    };
+
+    let x1 = x0 - i1 as f32 + SIMPLEX_G3;
+    let y1 = y0 - j1 as f32 + SIMPLEX_G3;
+    let z1 = z0 - k1 as f32 + SIMPLEX_G3;
+    let x2 = x0 - i2 as f32 + 2.0 * SIMPLEX_G3;
+    let y2 = y0 - j2 as f32 + 2.0 * SIMPLEX_G3;
+    let z2 = z0 - k2 as f32 + 2.0 * SIMPLEX_G3;
+    let x3 = x0 - 1.0 + 3.0 * SIMPLEX_G3;
+    let y3 = y0 - 1.0 + 3.0 * SIMPLEX_G3;
+    let z3 = z0 - 1.0 + 3.0 * SIMPLEX_G3;
+
+    let contrib = |xi: i32, yi: i32, zi: i32, dx: f32, dy: f32, dz: f32| -> f32 {
+        let t = 0.6 - dx * dx - dy * dy - dz * dz;
+        if t < 0.0 {
+            0.0
+        } else {
+            let t2 = t * t;
+            t2 * t2 * grad_dot_3d(gradient_3d(hash_3d(xi, yi, zi)), dx, dy, dz)
+        }
+    };
+
+    32.0 * (
+        contrib(i,      j,      k,      x0, y0, z0)
+      + contrib(i + i1, j + j1, k + k1, x1, y1, z1)
+      + contrib(i + i2, j + j2, k + k2, x2, y2, z2)
+      + contrib(i + 1,  j + 1,  k + 1,  x3, y3, z3)
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Domain warping
+// ---------------------------------------------------------------------------
+
+/// Domain-warped FBM in 2-D.
+///
+/// Samples two independent FBM fields as a warp vector, then samples a third
+/// FBM at the warped position. Produces swirling, turbulent shapes with rich
+/// self-similar structure not achievable by plain FBM.
+///
+/// # Math
+///
+/// ```text
+/// warp_x = fbm_2d(x + 0.0, y + 0.0, ...)
+/// warp_y = fbm_2d(x + 5.2, y + 1.3, ...)   ← offset breaks correlation
+/// result = fbm_2d(x + warp_scale * warp_x,
+///                 y + warp_scale * warp_y, ...)
+/// ```
+///
+/// # Arguments
+/// * `x`, `y`      — input coordinates
+/// * `octaves`     — FBM octave count
+/// * `lacunarity`  — frequency multiplier per octave
+/// * `gain`        — amplitude multiplier per octave
+/// * `warp_scale`  — how far the domain is displaced (typically 1.0–2.0)
+///
+/// # Returns
+/// An FBM-range value (not clamped).
+///
+/// # Example
+/// ```rust
+/// use prime_noise::domain_warp_2d;
+/// let v = domain_warp_2d(0.3, 0.7, 6, 2.0, 0.5, 1.0);
+/// assert!(v.abs() < 4.0);
+/// ```
+pub fn domain_warp_2d(x: f32, y: f32, octaves: u32, lacunarity: f32, gain: f32, warp_scale: f32) -> f32 {
+    let wx = fbm_2d(x,       y,       octaves, lacunarity, gain);
+    let wy = fbm_2d(x + 5.2, y + 1.3, octaves, lacunarity, gain);
+    fbm_2d(x + warp_scale * wx, y + warp_scale * wy, octaves, lacunarity, gain)
+}
+
+/// Domain-warped FBM in 3-D.
+///
+/// Three independent FBM fields are sampled as a warp vector (with offsets to
+/// break correlation), then a fourth FBM is evaluated at the warped position.
+///
+/// # Math
+///
+/// ```text
+/// wx = fbm_3d(x+0.0, y+0.0, z+0.0, ...)
+/// wy = fbm_3d(x+5.2, y+1.3, z+2.7, ...)
+/// wz = fbm_3d(x+3.1, y+7.4, z+0.9, ...)
+/// result = fbm_3d(x + warp_scale*wx, y + warp_scale*wy, z + warp_scale*wz, ...)
+/// ```
+///
+/// # Arguments
+/// * `x`, `y`, `z` — input coordinates
+/// * `octaves`     — FBM octave count
+/// * `lacunarity`  — frequency multiplier per octave
+/// * `gain`        — amplitude multiplier per octave
+/// * `warp_scale`  — domain displacement magnitude
+///
+/// # Returns
+/// An FBM-range value (not clamped).
+///
+/// # Example
+/// ```rust
+/// use prime_noise::domain_warp_3d;
+/// let v = domain_warp_3d(0.3, 0.7, 0.2, 4, 2.0, 0.5, 1.0);
+/// assert!(v.abs() < 4.0);
+/// ```
+pub fn domain_warp_3d(x: f32, y: f32, z: f32, octaves: u32, lacunarity: f32, gain: f32, warp_scale: f32) -> f32 {
+    let wx = fbm_3d(x,       y,       z,       octaves, lacunarity, gain);
+    let wy = fbm_3d(x + 5.2, y + 1.3, z + 2.7, octaves, lacunarity, gain);
+    let wz = fbm_3d(x + 3.1, y + 7.4, z + 0.9, octaves, lacunarity, gain);
+    fbm_3d(x + warp_scale * wx, y + warp_scale * wy, z + warp_scale * wz, octaves, lacunarity, gain)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -558,5 +980,179 @@ mod tests {
         // surrounding 3x3 block — distance must be > 0.
         let d = worley_2d(0.5, 0.5, 7);
         assert!(d > 0.0, "distance at cell centre should be positive");
+    }
+
+    // --- value_noise_3d ---
+
+    #[test]
+    fn value_noise_3d_range() {
+        for (x, y, z) in [(0.5, 0.5, 0.5), (1.234, 5.678, 2.345), (-3.1, 2.9, 1.1)] {
+            let v = value_noise_3d(x, y, z);
+            assert!(v >= 0.0 && v <= 1.0, "value_noise_3d({x},{y},{z})={v}");
+        }
+    }
+
+    #[test]
+    fn value_noise_3d_deterministic() {
+        let a = value_noise_3d(1.1, 2.2, 3.3);
+        let b = value_noise_3d(1.1, 2.2, 3.3);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn value_noise_3d_at_integer_lattice() {
+        let v = value_noise_3d(2.0, 3.0, 4.0);
+        let expected = hash_3d(2, 3, 4);
+        assert!((v - expected).abs() < EPSILON, "v={v}, expected={expected}");
+    }
+
+    #[test]
+    fn value_noise_3d_different_coords_differ() {
+        assert_ne!(value_noise_3d(0.5, 0.5, 0.5), value_noise_3d(1.5, 0.5, 0.5));
+    }
+
+    // --- perlin_3d ---
+
+    #[test]
+    fn perlin_3d_range_approx() {
+        for (x, y, z) in [(0.5, 0.5, 0.5), (1.234, 5.678, 2.3), (-3.1, 2.9, 0.7)] {
+            let v = perlin_3d(x, y, z);
+            assert!(v >= -1.5 && v <= 1.5, "perlin_3d({x},{y},{z})={v}");
+        }
+    }
+
+    #[test]
+    fn perlin_3d_deterministic() {
+        let a = perlin_3d(1.1, 2.2, 3.3);
+        let b = perlin_3d(1.1, 2.2, 3.3);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn perlin_3d_zero_at_integer_lattice() {
+        for (x, y, z) in [(0, 0, 0), (1, 2, 3), (-1, 4, -2)] {
+            let v = perlin_3d(x as f32, y as f32, z as f32);
+            assert!(v.abs() < EPSILON, "perlin_3d({x},{y},{z})={v}");
+        }
+    }
+
+    #[test]
+    fn perlin_3d_different_coords_differ() {
+        assert_ne!(perlin_3d(0.3, 0.7, 0.5), perlin_3d(0.7, 0.3, 0.5));
+    }
+
+    // --- fbm_3d ---
+
+    #[test]
+    fn fbm_3d_zero_octaves_returns_zero() {
+        assert_eq!(fbm_3d(1.0, 2.0, 3.0, 0, 2.0, 0.5), 0.0);
+    }
+
+    #[test]
+    fn fbm_3d_one_octave_equals_perlin() {
+        let v_fbm = fbm_3d(0.4, 0.8, 0.2, 1, 2.0, 0.5);
+        let v_perlin = perlin_3d(0.4, 0.8, 0.2);
+        assert!((v_fbm - v_perlin).abs() < EPSILON);
+    }
+
+    #[test]
+    fn fbm_3d_deterministic() {
+        let a = fbm_3d(0.5, 0.5, 0.5, 6, 2.0, 0.5);
+        let b = fbm_3d(0.5, 0.5, 0.5, 6, 2.0, 0.5);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn fbm_3d_bounded() {
+        let v = fbm_3d(0.3, 0.7, 0.2, 8, 2.0, 0.5);
+        assert!(v.abs() < 3.0, "fbm_3d={v}");
+    }
+
+    // --- simplex_2d ---
+
+    #[test]
+    fn simplex_2d_range() {
+        for (x, y) in [(0.5, 0.5), (1.2, 3.4), (-2.1, 0.7), (100.0, 200.0)] {
+            let v = simplex_2d(x, y);
+            assert!(v >= -1.1 && v <= 1.1, "simplex_2d({x},{y})={v}");
+        }
+    }
+
+    #[test]
+    fn simplex_2d_deterministic() {
+        let a = simplex_2d(1.1, 2.2);
+        let b = simplex_2d(1.1, 2.2);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn simplex_2d_different_coords_differ() {
+        assert_ne!(simplex_2d(0.3, 0.7), simplex_2d(0.7, 0.3));
+    }
+
+    // --- simplex_3d ---
+
+    #[test]
+    fn simplex_3d_range() {
+        for (x, y, z) in [(0.5, 0.5, 0.5), (1.2, 3.4, 2.1), (-2.1, 0.7, 1.3)] {
+            let v = simplex_3d(x, y, z);
+            assert!(v >= -1.1 && v <= 1.1, "simplex_3d({x},{y},{z})={v}");
+        }
+    }
+
+    #[test]
+    fn simplex_3d_deterministic() {
+        let a = simplex_3d(1.1, 2.2, 3.3);
+        let b = simplex_3d(1.1, 2.2, 3.3);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn simplex_3d_different_coords_differ() {
+        assert_ne!(simplex_3d(0.3, 0.7, 0.2), simplex_3d(0.7, 0.3, 0.2));
+    }
+
+    // --- domain_warp_2d ---
+
+    #[test]
+    fn domain_warp_2d_deterministic() {
+        let a = domain_warp_2d(0.3, 0.7, 4, 2.0, 0.5, 1.0);
+        let b = domain_warp_2d(0.3, 0.7, 4, 2.0, 0.5, 1.0);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn domain_warp_2d_differs_from_plain_fbm() {
+        let warped = domain_warp_2d(0.3, 0.7, 4, 2.0, 0.5, 1.0);
+        let plain = fbm_2d(0.3, 0.7, 4, 2.0, 0.5);
+        assert_ne!(warped, plain);
+    }
+
+    #[test]
+    fn domain_warp_2d_bounded() {
+        let v = domain_warp_2d(0.3, 0.7, 6, 2.0, 0.5, 1.0);
+        assert!(v.abs() < 4.0, "domain_warp_2d={v}");
+    }
+
+    // --- domain_warp_3d ---
+
+    #[test]
+    fn domain_warp_3d_deterministic() {
+        let a = domain_warp_3d(0.3, 0.7, 0.2, 4, 2.0, 0.5, 1.0);
+        let b = domain_warp_3d(0.3, 0.7, 0.2, 4, 2.0, 0.5, 1.0);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn domain_warp_3d_differs_from_plain_fbm() {
+        let warped = domain_warp_3d(0.3, 0.7, 0.2, 4, 2.0, 0.5, 1.0);
+        let plain = fbm_3d(0.3, 0.7, 0.2, 4, 2.0, 0.5);
+        assert_ne!(warped, plain);
+    }
+
+    #[test]
+    fn domain_warp_3d_bounded() {
+        let v = domain_warp_3d(0.3, 0.7, 0.2, 4, 2.0, 0.5, 1.0);
+        assert!(v.abs() < 4.0, "domain_warp_3d={v}");
     }
 }

--- a/packages/prime-noise/src/__tests__/noise.test.ts
+++ b/packages/prime-noise/src/__tests__/noise.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { valueNoise2d, perlin2d, fbm2d, worley2d } from '../index'
+import {
+  valueNoise2d, perlin2d, fbm2d, worley2d,
+  valueNoise3d, perlin3d, fbm3d,
+  simplex2d, simplex3d,
+  domainWarp2d, domainWarp3d,
+} from '../index'
 
 const EPSILON = 1e-5
 
@@ -270,5 +275,126 @@ describe('cross-function consistency', () => {
     const pn = perlin2d(0.5, 0.5)
     // Different algorithms — should not coincidentally match
     expect(vn).not.toBeCloseTo(pn, 3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3-D noise
+// ---------------------------------------------------------------------------
+
+const EPS = 1e-5
+
+describe('valueNoise3d', () => {
+  it('range [0, 1]', () => {
+    [[0.5, 0.5, 0.5], [1.234, 5.678, 2.345], [-3.1, 2.9, 1.1]].forEach(([x, y, z]) => {
+      const v = valueNoise3d(x, y, z)
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThanOrEqual(1)
+    })
+  })
+
+  it('deterministic', () => {
+    expect(valueNoise3d(1.1, 2.2, 3.3)).toBe(valueNoise3d(1.1, 2.2, 3.3))
+  })
+
+  it('different coords differ', () => {
+    expect(valueNoise3d(0.5, 0.5, 0.5)).not.toBe(valueNoise3d(1.5, 0.5, 0.5))
+  })
+})
+
+describe('perlin3d', () => {
+  it('range approx [-1.5, 1.5]', () => {
+    [[0.5, 0.5, 0.5], [1.234, 5.678, 2.3], [-3.1, 2.9, 0.7]].forEach(([x, y, z]) => {
+      const v = perlin3d(x, y, z)
+      expect(v).toBeGreaterThanOrEqual(-1.5)
+      expect(v).toBeLessThanOrEqual(1.5)
+    })
+  })
+
+  it('deterministic', () => {
+    expect(perlin3d(1.1, 2.2, 3.3)).toBe(perlin3d(1.1, 2.2, 3.3))
+  })
+
+  it('zero at integer lattice points', () => {
+    expect(Math.abs(perlin3d(0, 0, 0))).toBeLessThan(EPS)
+    expect(Math.abs(perlin3d(1, 2, 3))).toBeLessThan(EPS)
+  })
+
+  it('different coords differ', () => {
+    expect(perlin3d(0.3, 0.7, 0.5)).not.toBe(perlin3d(0.7, 0.3, 0.5))
+  })
+})
+
+describe('fbm3d', () => {
+  it('0 octaves returns 0', () => {
+    expect(fbm3d(1, 2, 3, 0, 2, 0.5)).toBe(0)
+  })
+
+  it('1 octave equals perlin3d', () => {
+    expect(Math.abs(fbm3d(0.4, 0.8, 0.2, 1, 2, 0.5) - perlin3d(0.4, 0.8, 0.2))).toBeLessThan(EPS)
+  })
+
+  it('deterministic', () => {
+    expect(fbm3d(0.5, 0.5, 0.5, 6, 2, 0.5)).toBe(fbm3d(0.5, 0.5, 0.5, 6, 2, 0.5))
+  })
+
+  it('bounded with standard params', () => {
+    expect(Math.abs(fbm3d(0.3, 0.7, 0.2, 8, 2, 0.5))).toBeLessThan(3)
+  })
+})
+
+describe('simplex2d', () => {
+  it('range approx [-1.1, 1.1]', () => {
+    [[0.5, 0.5], [1.2, 3.4], [-2.1, 0.7]].forEach(([x, y]) => {
+      const v = simplex2d(x, y)
+      expect(v).toBeGreaterThanOrEqual(-1.1)
+      expect(v).toBeLessThanOrEqual(1.1)
+    })
+  })
+
+  it('deterministic', () => {
+    expect(simplex2d(1.1, 2.2)).toBe(simplex2d(1.1, 2.2))
+  })
+
+  it('different coords differ', () => {
+    expect(simplex2d(0.3, 0.7)).not.toBe(simplex2d(0.7, 0.3))
+  })
+})
+
+describe('simplex3d', () => {
+  it('range approx [-1.1, 1.1]', () => {
+    [[0.5, 0.5, 0.5], [1.2, 3.4, 2.1], [-2.1, 0.7, 1.3]].forEach(([x, y, z]) => {
+      const v = simplex3d(x, y, z)
+      expect(v).toBeGreaterThanOrEqual(-1.1)
+      expect(v).toBeLessThanOrEqual(1.1)
+    })
+  })
+
+  it('deterministic', () => {
+    expect(simplex3d(1.1, 2.2, 3.3)).toBe(simplex3d(1.1, 2.2, 3.3))
+  })
+
+  it('different coords differ', () => {
+    expect(simplex3d(0.3, 0.7, 0.2)).not.toBe(simplex3d(0.7, 0.3, 0.2))
+  })
+})
+
+describe('domainWarp2d', () => {
+  it('deterministic', () => {
+    expect(domainWarp2d(0.3, 0.7, 4, 2, 0.5, 1)).toBe(domainWarp2d(0.3, 0.7, 4, 2, 0.5, 1))
+  })
+
+  it('differs from plain fbm2d', () => {
+    expect(domainWarp2d(0.3, 0.7, 4, 2, 0.5, 1)).not.toBe(fbm2d(0.3, 0.7, 4, 2, 0.5))
+  })
+})
+
+describe('domainWarp3d', () => {
+  it('deterministic', () => {
+    expect(domainWarp3d(0.3, 0.7, 0.2, 4, 2, 0.5, 1)).toBe(domainWarp3d(0.3, 0.7, 0.2, 4, 2, 0.5, 1))
+  })
+
+  it('differs from plain fbm3d', () => {
+    expect(domainWarp3d(0.3, 0.7, 0.2, 4, 2, 0.5, 1)).not.toBe(fbm3d(0.3, 0.7, 0.2, 4, 2, 0.5))
   })
 })

--- a/packages/prime-noise/src/index.ts
+++ b/packages/prime-noise/src/index.ts
@@ -342,3 +342,363 @@ export const worley2d = (x: number, y: number, seed: number): number => {
 
   return Math.min(Math.max(minDist, 0), 1)
 }
+
+// ---------------------------------------------------------------------------
+// 3-D internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Hash a 3-D integer lattice coordinate to a float in [0, 1].
+ *
+ * Mirrors Rust `hash_3d`: chains three `wrapping_add`s in u32 space.
+ */
+const hash3d = (xi: number, yi: number, zi: number): number => {
+  const inner = ((hashU32(xi >>> 0) + (yi >>> 0)) >>> 0)
+  const h = hashU32(((hashU32(inner) + (zi >>> 0)) >>> 0))
+  return h / 4294967295
+}
+
+/**
+ * Twelve gradient vectors: midpoints of the edges of a unit cube.
+ *
+ * Matches Rust `GRADIENTS_3D` exactly (all integer components ∈ {-1, 0, 1}).
+ */
+const GRADIENTS_3D: readonly [number, number, number][] = [
+  [1, 1, 0],  [-1, 1, 0],  [1, -1, 0],  [-1, -1, 0],
+  [1, 0, 1],  [-1, 0, 1],  [1, 0, -1],  [-1, 0, -1],
+  [0, 1, 1],  [0, -1, 1],  [0, 1, -1],  [0, -1, -1],
+]
+
+/** Map a lattice hash in [0, 1] to one of the twelve 3-D gradient vectors. */
+const gradient3d = (h: number): [number, number, number] =>
+  GRADIENTS_3D[Math.floor(h * 12) % 12] as [number, number, number]
+
+/** Dot product of a 3-D gradient with offset `(dx, dy, dz)`. */
+const gradDot3d = (g: [number, number, number], dx: number, dy: number, dz: number): number =>
+  g[0] * dx + g[1] * dy + g[2] * dz
+
+// ---------------------------------------------------------------------------
+// 3-D value noise
+// ---------------------------------------------------------------------------
+
+/**
+ * Smooth value noise at a 3-D point.
+ *
+ * Trilinear interpolation of hash values at the 8 integer lattice corners,
+ * smoothed with the smoothstep fade curve.
+ *
+ * @param x - x coordinate (any finite number)
+ * @param y - y coordinate (any finite number)
+ * @param z - z coordinate (any finite number)
+ * @returns A value in [0, 1].
+ *
+ * @example
+ * ```ts
+ * const v = valueNoise3d(1.5, 2.3, 0.7)
+ * // v is in [0, 1]
+ * ```
+ */
+export const valueNoise3d = (x: number, y: number, z: number): number => {
+  const xi = Math.floor(x)
+  const yi = Math.floor(y)
+  const zi = Math.floor(z)
+  const fx = x - xi
+  const fy = y - yi
+  const fz = z - zi
+
+  const tx = smoothstep(fx)
+  const ty = smoothstep(fy)
+  const tz = smoothstep(fz)
+
+  const v000 = hash3d(xi,     yi,     zi    )
+  const v100 = hash3d(xi + 1, yi,     zi    )
+  const v010 = hash3d(xi,     yi + 1, zi    )
+  const v110 = hash3d(xi + 1, yi + 1, zi    )
+  const v001 = hash3d(xi,     yi,     zi + 1)
+  const v101 = hash3d(xi + 1, yi,     zi + 1)
+  const v011 = hash3d(xi,     yi + 1, zi + 1)
+  const v111 = hash3d(xi + 1, yi + 1, zi + 1)
+
+  const bot = lerp(lerp(v000, v100, tx), lerp(v010, v110, tx), ty)
+  const top = lerp(lerp(v001, v101, tx), lerp(v011, v111, tx), ty)
+  return lerp(bot, top, tz)
+}
+
+// ---------------------------------------------------------------------------
+// 3-D Perlin noise
+// ---------------------------------------------------------------------------
+
+/**
+ * Classic Perlin gradient noise at a 3-D point.
+ *
+ * Trilinear blend of gradient dot products from the 8 lattice corners.
+ * Returns 0 at exact integer lattice points.
+ *
+ * @param x - x coordinate
+ * @param y - y coordinate
+ * @param z - z coordinate
+ * @returns Approximately in [-1, 1]. Not clamped.
+ *
+ * @example
+ * ```ts
+ * const v = perlin3d(0.5, 0.5, 0.5)
+ * perlin3d(1.0, 2.0, 3.0) // 0
+ * ```
+ */
+export const perlin3d = (x: number, y: number, z: number): number => {
+  const xi = Math.floor(x)
+  const yi = Math.floor(y)
+  const zi = Math.floor(z)
+  const fx = x - xi
+  const fy = y - yi
+  const fz = z - zi
+
+  const tx = smoothstep(fx)
+  const ty = smoothstep(fy)
+  const tz = smoothstep(fz)
+
+  const g000 = gradient3d(hash3d(xi,     yi,     zi    ))
+  const g100 = gradient3d(hash3d(xi + 1, yi,     zi    ))
+  const g010 = gradient3d(hash3d(xi,     yi + 1, zi    ))
+  const g110 = gradient3d(hash3d(xi + 1, yi + 1, zi    ))
+  const g001 = gradient3d(hash3d(xi,     yi,     zi + 1))
+  const g101 = gradient3d(hash3d(xi + 1, yi,     zi + 1))
+  const g011 = gradient3d(hash3d(xi,     yi + 1, zi + 1))
+  const g111 = gradient3d(hash3d(xi + 1, yi + 1, zi + 1))
+
+  const n000 = gradDot3d(g000, fx,     fy,     fz    )
+  const n100 = gradDot3d(g100, fx - 1, fy,     fz    )
+  const n010 = gradDot3d(g010, fx,     fy - 1, fz    )
+  const n110 = gradDot3d(g110, fx - 1, fy - 1, fz    )
+  const n001 = gradDot3d(g001, fx,     fy,     fz - 1)
+  const n101 = gradDot3d(g101, fx - 1, fy,     fz - 1)
+  const n011 = gradDot3d(g011, fx,     fy - 1, fz - 1)
+  const n111 = gradDot3d(g111, fx - 1, fy - 1, fz - 1)
+
+  const bot = lerp(lerp(n000, n100, tx), lerp(n010, n110, tx), ty)
+  const top = lerp(lerp(n001, n101, tx), lerp(n011, n111, tx), ty)
+  return lerp(bot, top, tz)
+}
+
+/**
+ * Fractional Brownian Motion over 3-D Perlin noise.
+ *
+ * @param x          - x coordinate
+ * @param y          - y coordinate
+ * @param z          - z coordinate
+ * @param octaves    - noise layers (0 returns 0)
+ * @param lacunarity - frequency multiplier per octave (typically 2.0)
+ * @param gain       - amplitude multiplier per octave (typically 0.5)
+ * @returns Sum of all octave contributions. Not clamped.
+ *
+ * @example
+ * ```ts
+ * const v = fbm3d(0.3, 0.7, 0.2, 6, 2.0, 0.5)
+ * ```
+ */
+export const fbm3d = (
+  x: number,
+  y: number,
+  z: number,
+  octaves: number,
+  lacunarity: number,
+  gain: number,
+): number => {
+  const [value] = Array.from<null>({ length: octaves }).reduce(
+    ([acc, freq, amp]: [number, number, number]): [number, number, number] => [
+      acc + amp * perlin3d(x * freq, y * freq, z * freq),
+      freq * lacunarity,
+      amp * gain,
+    ],
+    [0, 1, 1] as [number, number, number],
+  )
+  return value
+}
+
+// ---------------------------------------------------------------------------
+// Simplex noise (2-D and 3-D)
+// ---------------------------------------------------------------------------
+
+// Skew / unskew constants (match Rust SIMPLEX_F2 / SIMPLEX_G2 / SIMPLEX_F3 / SIMPLEX_G3).
+const SIMPLEX_F2 = 0.3660254   // (sqrt(3) - 1) / 2
+const SIMPLEX_G2 = 0.21132487  // (3 - sqrt(3)) / 6
+const SIMPLEX_F3 = 1 / 3
+const SIMPLEX_G3 = 1 / 6
+
+/**
+ * Simplex noise at a 2-D point.
+ *
+ * Uses triangular simplex cells — no directional artifacts, 3 corners
+ * evaluated instead of 4.
+ *
+ * @param x - x coordinate (any finite number)
+ * @param y - y coordinate (any finite number)
+ * @returns Approximately in [-1, 1]. Not clamped.
+ *
+ * @example
+ * ```ts
+ * const v = simplex2d(0.5, 0.5)
+ * ```
+ */
+export const simplex2d = (x: number, y: number): number => {
+  const s = (x + y) * SIMPLEX_F2
+  const i = Math.floor(x + s)
+  const j = Math.floor(y + s)
+
+  const t = (i + j) * SIMPLEX_G2
+  const x0 = x - (i - t)
+  const y0 = y - (j - t)
+
+  const [i1, j1] = x0 > y0 ? [1, 0] : [0, 1]
+
+  const x1 = x0 - i1 + SIMPLEX_G2
+  const y1 = y0 - j1 + SIMPLEX_G2
+  const x2 = x0 - 1 + 2 * SIMPLEX_G2
+  const y2 = y0 - 1 + 2 * SIMPLEX_G2
+
+  const contrib = (xi: number, yi: number, dx: number, dy: number): number => {
+    const tc = 0.5 - dx * dx - dy * dy
+    if (tc < 0) return 0
+    const t2 = tc * tc
+    return t2 * t2 * gradDot(gradient(hash2d(xi, yi)), dx, dy)
+  }
+
+  return 70 * (contrib(i, j, x0, y0) + contrib(i + i1, j + j1, x1, y1) + contrib(i + 1, j + 1, x2, y2))
+}
+
+/**
+ * Simplex noise at a 3-D point.
+ *
+ * Evaluates 4 tetrahedral corners. Fewer evaluations and no axis-aligned
+ * artifacts compared to 3-D Perlin.
+ *
+ * @param x - x coordinate (any finite number)
+ * @param y - y coordinate (any finite number)
+ * @param z - z coordinate (any finite number)
+ * @returns Approximately in [-1, 1]. Not clamped.
+ *
+ * @example
+ * ```ts
+ * const v = simplex3d(0.5, 0.5, 0.5)
+ * ```
+ */
+export const simplex3d = (x: number, y: number, z: number): number => {
+  const s = (x + y + z) * SIMPLEX_F3
+  const i = Math.floor(x + s)
+  const j = Math.floor(y + s)
+  const k = Math.floor(z + s)
+
+  const t = (i + j + k) * SIMPLEX_G3
+  const x0 = x - (i - t)
+  const y0 = y - (j - t)
+  const z0 = z - (k - t)
+
+  // Which tetrahedron?
+  const [i1, j1, k1, i2, j2, k2] = x0 >= y0
+    ? y0 >= z0      ? [1, 0, 0, 1, 1, 0]
+    : x0 >= z0      ? [1, 0, 0, 1, 0, 1]
+    :                 [0, 0, 1, 1, 0, 1]
+    : y0 < z0       ? [0, 0, 1, 0, 1, 1]
+    : x0 < z0       ? [0, 1, 0, 0, 1, 1]
+    :                 [0, 1, 0, 1, 1, 0]
+
+  const x1 = x0 - i1 + SIMPLEX_G3
+  const y1 = y0 - j1 + SIMPLEX_G3
+  const z1 = z0 - k1 + SIMPLEX_G3
+  const x2 = x0 - i2 + 2 * SIMPLEX_G3
+  const y2 = y0 - j2 + 2 * SIMPLEX_G3
+  const z2 = z0 - k2 + 2 * SIMPLEX_G3
+  const x3 = x0 - 1 + 3 * SIMPLEX_G3
+  const y3 = y0 - 1 + 3 * SIMPLEX_G3
+  const z3 = z0 - 1 + 3 * SIMPLEX_G3
+
+  const contrib = (xi: number, yi: number, zi: number, dx: number, dy: number, dz: number): number => {
+    const tc = 0.6 - dx * dx - dy * dy - dz * dz
+    if (tc < 0) return 0
+    const t2 = tc * tc
+    return t2 * t2 * gradDot3d(gradient3d(hash3d(xi, yi, zi)), dx, dy, dz)
+  }
+
+  return 32 * (
+    contrib(i,      j,      k,      x0, y0, z0)
+  + contrib(i + i1, j + j1, k + k1, x1, y1, z1)
+  + contrib(i + i2, j + j2, k + k2, x2, y2, z2)
+  + contrib(i + 1,  j + 1,  k + 1,  x3, y3, z3)
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Domain warping
+// ---------------------------------------------------------------------------
+
+/**
+ * Domain-warped FBM in 2-D.
+ *
+ * Samples two independent FBM fields as a warp vector then evaluates FBM at
+ * the warped position. Produces swirling turbulent shapes.
+ *
+ * @param x          - x coordinate
+ * @param y          - y coordinate
+ * @param octaves    - FBM octave count
+ * @param lacunarity - frequency multiplier per octave
+ * @param gain       - amplitude multiplier per octave
+ * @param warpScale  - domain displacement magnitude (typically 1.0–2.0)
+ * @returns An FBM-range value. Not clamped.
+ *
+ * @example
+ * ```ts
+ * const v = domainWarp2d(0.3, 0.7, 6, 2.0, 0.5, 1.0)
+ * ```
+ */
+export const domainWarp2d = (
+  x: number,
+  y: number,
+  octaves: number,
+  lacunarity: number,
+  gain: number,
+  warpScale: number,
+): number => {
+  const wx = fbm2d(x,       y,       octaves, lacunarity, gain)
+  const wy = fbm2d(x + 5.2, y + 1.3, octaves, lacunarity, gain)
+  return fbm2d(x + warpScale * wx, y + warpScale * wy, octaves, lacunarity, gain)
+}
+
+/**
+ * Domain-warped FBM in 3-D.
+ *
+ * Three independent FBM fields provide the warp vector; a fourth FBM samples
+ * the warped position.
+ *
+ * @param x          - x coordinate
+ * @param y          - y coordinate
+ * @param z          - z coordinate
+ * @param octaves    - FBM octave count
+ * @param lacunarity - frequency multiplier per octave
+ * @param gain       - amplitude multiplier per octave
+ * @param warpScale  - domain displacement magnitude
+ * @returns An FBM-range value. Not clamped.
+ *
+ * @example
+ * ```ts
+ * const v = domainWarp3d(0.3, 0.7, 0.2, 4, 2.0, 0.5, 1.0)
+ * ```
+ */
+export const domainWarp3d = (
+  x: number,
+  y: number,
+  z: number,
+  octaves: number,
+  lacunarity: number,
+  gain: number,
+  warpScale: number,
+): number => {
+  const wx = fbm3d(x,       y,       z,       octaves, lacunarity, gain)
+  const wy = fbm3d(x + 5.2, y + 1.3, z + 2.7, octaves, lacunarity, gain)
+  const wz = fbm3d(x + 3.1, y + 7.4, z + 0.9, octaves, lacunarity, gain)
+  return fbm3d(
+    x + warpScale * wx,
+    y + warpScale * wy,
+    z + warpScale * wz,
+    octaves, lacunarity, gain,
+  )
+}


### PR DESCRIPTION
Stacked on feat/prime-dynamics. Adds value_noise_3d, perlin_3d, fbm_3d, simplex_2d, simplex_3d, domain_warp_2d, domain_warp_3d in Rust + TS. 42 Rust unit + 11 doc tests, 45 TS tests.