### PR TITLE
audit: full coverage pass — edge cases, WASM gaps, overflow fix

### DIFF
--- a/crates/prime-color/src/lib.rs
+++ b/crates/prime-color/src/lib.rs
@@ -760,4 +760,40 @@ mod tests {
         // Should be roughly mid-gray in sRGB (not necessarily 0.5 exactly due to Oklab L)
         assert!(r > 0.1 && r < 0.9, "gray value out of expected range: {}", r);
     }
+
+    // ── out-of-range [0,1] inputs ─────────────────────────────────────────────
+
+    #[test]
+    fn srgb_to_oklab_over_range_is_finite() {
+        // sRGB > 1.0 (HDR-style) — must not produce NaN.
+        let (l, a, b) = srgb_to_oklab(1.5, 0.5, 0.5);
+        assert!(l.is_finite() && a.is_finite() && b.is_finite(),
+            "srgb_to_oklab(1.5,...) produced non-finite: {:?}", (l, a, b));
+    }
+
+    #[test]
+    fn srgb_to_linear_over_range_is_finite() {
+        let (lr, lg, lb) = srgb_to_linear(2.0, 0.0, 0.0);
+        assert!(lr.is_finite() && lg.is_finite() && lb.is_finite());
+    }
+
+    #[test]
+    fn oklab_to_srgb_out_of_gamut_is_finite() {
+        // Push an extreme Oklab value — output may be out of [0,1] but must be finite.
+        let (r, g, b) = oklab_to_srgb(1.0, 0.5, 0.5);
+        assert!(r.is_finite() && g.is_finite() && b.is_finite(),
+            "oklab_to_srgb with large a/b produced non-finite: {:?}", (r, g, b));
+    }
+
+    #[test]
+    fn hsl_to_srgb_hue_boundary_is_finite() {
+        // h=0.0 and h=1.0 are both valid boundary values — must be finite.
+        let at_0 = hsl_to_srgb(0.0, 1.0, 0.5);
+        let at_1 = hsl_to_srgb(1.0, 1.0, 0.5);
+        assert!(at_0.0.is_finite() && at_0.1.is_finite() && at_0.2.is_finite());
+        assert!(at_1.0.is_finite() && at_1.1.is_finite() && at_1.2.is_finite());
+        // Both endpoints should be red-family (high red channel)
+        assert!(at_0.0 > 0.9 && at_1.0 > 0.9,
+            "h=0 and h=1 should both be red-family; got {:?} and {:?}", at_0, at_1);
+    }
 }

--- a/crates/prime-diffusion/src/lib.rs
+++ b/crates/prime-diffusion/src/lib.rs
@@ -318,4 +318,38 @@ mod tests {
         });
         assert!(x > 0.0, "GBM chain must stay positive; x={x}");
     }
+
+    // ── box_muller near-zero u1 ───────────────────────────────────────────────
+
+    #[test]
+    fn box_muller_near_zero_u1_is_finite() {
+        // u1 near 0 (but > 0) → ln is large negative → result is large but finite.
+        let w = box_muller(f32::MIN_POSITIVE, 0.5);
+        assert!(w.is_finite(), "box_muller(MIN_POSITIVE, 0.5) produced non-finite: {w}");
+    }
+
+    #[test]
+    fn box_muller_typical_inputs_finite() {
+        // Normal operating range: u1, u2 in (0, 1).
+        let w = box_muller(0.5, 0.5);
+        assert!(w.is_finite(), "box_muller(0.5, 0.5) produced non-finite: {w}");
+        assert!((w).abs() < 10.0, "box_muller(0.5, 0.5) suspiciously large: {w}");
+    }
+
+    // ── ou_step / gbm_step edge cases ─────────────────────────────────────────
+
+    #[test]
+    fn ou_step_zero_theta_no_reversion() {
+        // theta=0 → no mean-reversion, only diffusion term.
+        let x = ou_step(5.0, 0.0, 0.0, 0.1, 0.01, 1.0);
+        // Should not snap to mu; should be near 5.0 + small diffusion.
+        assert!((x - 5.0).abs() < 0.5, "theta=0: x moved too far: {x}");
+    }
+
+    #[test]
+    fn gbm_step_zero_mu_sigma_unchanged() {
+        // mu=0, sigma=0, w=anything → GBM exponent = 0 → x unchanged.
+        let x = gbm_step(2.5, 0.0, 0.0, 0.01, 1.0);
+        assert!((x - 2.5).abs() < EPSILON, "gbm_step with sigma=mu=0 should return x; got {x}");
+    }
 }

--- a/crates/prime-noise/src/lib.rs
+++ b/crates/prime-noise/src/lib.rs
@@ -146,9 +146,9 @@ pub fn value_noise_2d(x: f32, y: f32) -> f32 {
     let ty = smoothstep(fy);
 
     let v00 = hash_2d(xi, yi);
-    let v10 = hash_2d(xi + 1, yi);
-    let v01 = hash_2d(xi, yi + 1);
-    let v11 = hash_2d(xi + 1, yi + 1);
+    let v10 = hash_2d(xi.wrapping_add(1), yi);
+    let v01 = hash_2d(xi, yi.wrapping_add(1));
+    let v11 = hash_2d(xi.wrapping_add(1), yi.wrapping_add(1));
 
     let bottom = lerp(v00, v10, tx);
     let top = lerp(v01, v11, tx);
@@ -208,9 +208,9 @@ pub fn perlin_2d(x: f32, y: f32) -> f32 {
     let ty = smoothstep(fy);
 
     let g00 = gradient(hash_2d(xi, yi));
-    let g10 = gradient(hash_2d(xi + 1, yi));
-    let g01 = gradient(hash_2d(xi, yi + 1));
-    let g11 = gradient(hash_2d(xi + 1, yi + 1));
+    let g10 = gradient(hash_2d(xi.wrapping_add(1), yi));
+    let g01 = gradient(hash_2d(xi, yi.wrapping_add(1)));
+    let g11 = gradient(hash_2d(xi.wrapping_add(1), yi.wrapping_add(1)));
 
     let n00 = grad_dot(g00, fx, fy);
     let n10 = grad_dot(g10, fx - 1.0, fy);
@@ -442,14 +442,18 @@ pub fn value_noise_3d(x: f32, y: f32, z: f32) -> f32 {
     let ty = smoothstep(fy);
     let tz = smoothstep(fz);
 
-    let v000 = hash_3d(xi,     yi,     zi    );
-    let v100 = hash_3d(xi + 1, yi,     zi    );
-    let v010 = hash_3d(xi,     yi + 1, zi    );
-    let v110 = hash_3d(xi + 1, yi + 1, zi    );
-    let v001 = hash_3d(xi,     yi,     zi + 1);
-    let v101 = hash_3d(xi + 1, yi,     zi + 1);
-    let v011 = hash_3d(xi,     yi + 1, zi + 1);
-    let v111 = hash_3d(xi + 1, yi + 1, zi + 1);
+    let xi1 = xi.wrapping_add(1);
+    let yi1 = yi.wrapping_add(1);
+    let zi1 = zi.wrapping_add(1);
+
+    let v000 = hash_3d(xi,  yi,  zi );
+    let v100 = hash_3d(xi1, yi,  zi );
+    let v010 = hash_3d(xi,  yi1, zi );
+    let v110 = hash_3d(xi1, yi1, zi );
+    let v001 = hash_3d(xi,  yi,  zi1);
+    let v101 = hash_3d(xi1, yi,  zi1);
+    let v011 = hash_3d(xi,  yi1, zi1);
+    let v111 = hash_3d(xi1, yi1, zi1);
 
     let bot = lerp(lerp(v000, v100, tx), lerp(v010, v110, tx), ty);
     let top = lerp(lerp(v001, v101, tx), lerp(v011, v111, tx), ty);
@@ -499,14 +503,18 @@ pub fn perlin_3d(x: f32, y: f32, z: f32) -> f32 {
     let ty = smoothstep(fy);
     let tz = smoothstep(fz);
 
-    let g000 = gradient_3d(hash_3d(xi,     yi,     zi    ));
-    let g100 = gradient_3d(hash_3d(xi + 1, yi,     zi    ));
-    let g010 = gradient_3d(hash_3d(xi,     yi + 1, zi    ));
-    let g110 = gradient_3d(hash_3d(xi + 1, yi + 1, zi    ));
-    let g001 = gradient_3d(hash_3d(xi,     yi,     zi + 1));
-    let g101 = gradient_3d(hash_3d(xi + 1, yi,     zi + 1));
-    let g011 = gradient_3d(hash_3d(xi,     yi + 1, zi + 1));
-    let g111 = gradient_3d(hash_3d(xi + 1, yi + 1, zi + 1));
+    let xi1 = xi.wrapping_add(1);
+    let yi1 = yi.wrapping_add(1);
+    let zi1 = zi.wrapping_add(1);
+
+    let g000 = gradient_3d(hash_3d(xi,  yi,  zi ));
+    let g100 = gradient_3d(hash_3d(xi1, yi,  zi ));
+    let g010 = gradient_3d(hash_3d(xi,  yi1, zi ));
+    let g110 = gradient_3d(hash_3d(xi1, yi1, zi ));
+    let g001 = gradient_3d(hash_3d(xi,  yi,  zi1));
+    let g101 = gradient_3d(hash_3d(xi1, yi,  zi1));
+    let g011 = gradient_3d(hash_3d(xi,  yi1, zi1));
+    let g111 = gradient_3d(hash_3d(xi1, yi1, zi1));
 
     let n000 = grad_dot_3d(g000, fx,       fy,       fz      );
     let n100 = grad_dot_3d(g100, fx - 1.0, fy,       fz      );
@@ -1154,5 +1162,47 @@ mod tests {
     fn domain_warp_3d_bounded() {
         let v = domain_warp_3d(0.3, 0.7, 0.2, 4, 2.0, 0.5, 1.0);
         assert!(v.abs() < 4.0, "domain_warp_3d={v}");
+    }
+
+    // ── large / negative / zero inputs ───────────────────────────────────────
+
+    #[test]
+    fn value_noise_2d_large_inputs_finite() {
+        assert!(value_noise_2d(1e10, 1e10).is_finite());
+    }
+
+    #[test]
+    fn perlin_2d_negative_inputs_finite() {
+        assert!(perlin_2d(-100.0, -200.0).is_finite());
+    }
+
+    #[test]
+    fn simplex_2d_zero_input_finite() {
+        assert!(simplex_2d(0.0, 0.0).is_finite());
+    }
+
+    #[test]
+    fn simplex_3d_large_inputs_finite() {
+        assert!(simplex_3d(1e6, 1e6, 1e6).is_finite());
+    }
+
+    #[test]
+    fn fbm_2d_zero_octaves_returns_zero() {
+        assert_eq!(fbm_2d(0.5, 0.5, 0, 2.0, 0.5), 0.0);
+    }
+
+    #[test]
+    fn fbm_3d_zero_octaves_returns_zero_edge() {
+        assert_eq!(fbm_3d(0.5, 0.5, 0.5, 0, 2.0, 0.5), 0.0);
+    }
+
+    #[test]
+    fn value_noise_3d_negative_inputs_finite() {
+        assert!(value_noise_3d(-50.0, -50.0, -50.0).is_finite());
+    }
+
+    #[test]
+    fn perlin_3d_large_inputs_finite() {
+        assert!(perlin_3d(1e8, 1e8, 1e8).is_finite());
     }
 }

--- a/crates/prime-signal/src/lib.rs
+++ b/crates/prime-signal/src/lib.rs
@@ -416,4 +416,26 @@ mod tests {
         let quad = deadzone(0.55, 0.1, 2.0);
         assert!(quad < linear, "quadratic curve should be smaller near deadzone");
     }
+
+    // ── spring edge cases ─────────────────────────────────────────────────────
+
+    #[test]
+    fn spring_zero_stiffness_no_nan() {
+        let (v1, vel1) = spring(1.0, 0.5, 0.0, 0.0, 0.5, 0.016);
+        assert!(v1.is_finite(), "value must be finite with stiffness=0; got {v1}");
+        assert!(vel1.is_finite(), "velocity must be finite with stiffness=0; got {vel1}");
+    }
+
+    #[test]
+    fn spring_zero_damping_accelerates_toward_target() {
+        let (_, vel) = spring(0.0, 0.0, 1.0, 100.0, 0.0, 0.016);
+        assert!(vel > 0.0, "undamped spring should accelerate toward target; vel={vel}");
+    }
+
+    #[test]
+    fn smoothdamp_zero_smooth_time_no_nan() {
+        let (v, vel) = smoothdamp(0.0, 1.0, 0.0, 0.0, 0.016);
+        assert!(v.is_finite() && vel.is_finite(),
+            "smooth_time=0 must not produce NaN/Inf; v={v} vel={vel}");
+    }
 }

--- a/crates/prime-spatial/src/lib.rs
+++ b/crates/prime-spatial/src/lib.rs
@@ -875,4 +875,51 @@ mod tests {
         let planes = unit_cube_frustum();
         assert!(frustum_cull_sphere(&planes, (3.0, 0.0, 0.0), 0.0));
     }
+
+    #[test]
+    fn frustum_cull_sphere_large_sphere_spans_frustum_not_culled() {
+        // Sphere so large it spans the entire frustum — should not be culled.
+        let planes = unit_cube_frustum();
+        assert!(!frustum_cull_sphere(&planes, (0.0, 0.0, 0.0), 100.0));
+    }
+
+    // ── degenerate AABB (min == max, zero-volume point) ───────────────────────
+
+    #[test]
+    fn aabb_overlap_degenerate_touching() {
+        assert!(aabb_overlaps((1.0, 1.0, 1.0), (1.0, 1.0, 1.0), (1.0, 1.0, 1.0), (1.0, 1.0, 1.0)));
+    }
+
+    #[test]
+    fn aabb_overlap_degenerate_apart() {
+        assert!(!aabb_overlaps((0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0), (1.0, 1.0, 1.0)));
+    }
+
+    #[test]
+    fn aabb_contains_degenerate_on_point() {
+        assert!(aabb_contains((1.0, 1.0, 1.0), (1.0, 1.0, 1.0), (1.0, 1.0, 1.0)));
+        assert!(!aabb_contains((1.0, 1.0, 1.0), (1.0, 1.0, 1.0), (1.0, 1.0, 1.1)));
+    }
+
+    #[test]
+    fn aabb_closest_point_degenerate() {
+        let cp = aabb_closest_point((1.0, 1.0, 1.0), (1.0, 1.0, 1.0), (5.0, 5.0, 5.0));
+        assert!(approx_eq3(cp, (1.0, 1.0, 1.0)));
+    }
+
+    // ── zero-direction ray (one component = 0) ────────────────────────────────
+
+    #[test]
+    fn ray_aabb_zero_x_dir_outside_slab_misses() {
+        // x-component of dir is 0; origin is outside x-slab [0,1] → miss.
+        let t = ray_aabb((5.0, 0.5, -5.0), (0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0));
+        assert!(t.is_none());
+    }
+
+    #[test]
+    fn ray_aabb_zero_x_dir_inside_slab_hits() {
+        // x-component of dir is 0; origin is inside x-slab → hits via z-travel.
+        let t = ray_aabb((0.5, 0.5, -5.0), (0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0));
+        assert!(t.is_some());
+    }
 }

--- a/crates/prime-splines/src/lib.rs
+++ b/crates/prime-splines/src/lib.rs
@@ -648,4 +648,47 @@ mod tests {
         let expected_w = std::f32::consts::FRAC_1_SQRT_2;
         assert!((mid.3.abs() - expected_w).abs() < 1e-3, "w={}", mid.3);
     }
+
+    // ── degenerate control points (all equal) ─────────────────────────────────
+
+    #[test]
+    fn bezier_quadratic_degenerate_returns_constant() {
+        assert!((bezier_quadratic(0.5, 3.0, 3.0, 3.0) - 3.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn bezier_cubic_degenerate_returns_constant() {
+        assert!((bezier_cubic(0.5, 2.0, 2.0, 2.0, 2.0) - 2.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn catmull_rom_degenerate_returns_constant() {
+        assert!((catmull_rom(0.5, 5.0, 5.0, 5.0, 5.0) - 5.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn hermite_degenerate_zero_tangents_returns_endpoints() {
+        // p0=p1, m0=m1=0 → flat line
+        assert!((hermite(0.0, 1.0, 0.0, 1.0, 0.0) - 1.0).abs() < EPSILON);
+        assert!((hermite(1.0, 1.0, 0.0, 1.0, 0.0) - 1.0).abs() < EPSILON);
+        assert!((hermite(0.5, 1.0, 0.0, 1.0, 0.0) - 1.0).abs() < EPSILON);
+    }
+
+    #[test]
+    fn b_spline_cubic_degenerate_returns_constant() {
+        assert!((b_spline_cubic(0.5, 4.0, 4.0, 4.0, 4.0) - 4.0).abs() < EPSILON);
+    }
+
+    // ── t outside [0, 1] ──────────────────────────────────────────────────────
+
+    #[test]
+    fn bezier_cubic_extrapolates_beyond_t1() {
+        // t > 1 → extrapolation, result should be finite
+        assert!(bezier_cubic(1.5, 0.0, 0.3, 0.7, 1.0).is_finite());
+    }
+
+    #[test]
+    fn catmull_rom_extrapolates_below_t0() {
+        assert!(catmull_rom(-0.5, 0.0, 1.0, 2.0, 3.0).is_finite());
+    }
 }

--- a/crates/prime-wasm/src/lib.rs
+++ b/crates/prime-wasm/src/lib.rs
@@ -217,6 +217,34 @@ pub fn prng_next(seed: f64) -> Box<[f64]> {
     vec![v as f64, next as f64].into_boxed_slice()
 }
 
+/// Sample uniform f32 in `[min, max]`. Returns `[value, next_seed]`.
+#[wasm_bindgen]
+pub fn prng_range_f32(seed: f64, min: f32, max: f32) -> Box<[f64]> {
+    let (v, next) = prime_random::prng_range_f32(seed as u32, min, max);
+    vec![v as f64, next as f64].into_boxed_slice()
+}
+
+/// Sample uniform integer in `[0, n)`. Returns `[index, next_seed]`.
+#[wasm_bindgen]
+pub fn prng_range_usize(seed: f64, n: f64) -> Box<[f64]> {
+    let (v, next) = prime_random::prng_range_usize(seed as u32, n as usize);
+    vec![v as f64, next as f64].into_boxed_slice()
+}
+
+/// Bernoulli trial with probability `p`. Returns `[0 or 1, next_seed]`.
+#[wasm_bindgen]
+pub fn prng_bool(seed: f64, p: f32) -> Box<[f64]> {
+    let (v, next) = prime_random::prng_bool(seed as u32, p);
+    vec![if v { 1.0 } else { 0.0 }, next as f64].into_boxed_slice()
+}
+
+/// Poisson-disk 2D sampling. Returns flat `[x0, y0, x1, y1, ...]`.
+#[wasm_bindgen]
+pub fn poisson_disk_2d(seed: f64, width: f32, height: f32, min_dist: f32, max_attempts: f64) -> Box<[f32]> {
+    let pts = prime_random::poisson_disk_2d(seed as u32, width, height, min_dist, max_attempts as usize);
+    pts.into_iter().flat_map(|(x, y)| [x, y]).collect::<Vec<f32>>().into_boxed_slice()
+}
+
 // ---------------------------------------------------------------------------
 // prime-osc
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Full pre-release audit across 5 dimensions. All math verified correct. One real bug found and fixed.

### Bug fix
- **prime-noise overflow**: `xi + 1`, `yi + 1`, `zi + 1` in lattice neighbor lookups used plain `i32` addition — panics on overflow in debug mode for inputs ≥ 2³¹ (e.g. `1e10`). Fixed all occurrences to `wrapping_add` in `value_noise_2d`, `value_noise_3d`, `perlin_3d`.

### WASM gaps closed
- `prime-wasm` was missing: `prng_range_f32`, `prng_range_usize`, `prng_bool`, `poisson_disk_2d`

### New tests (+33 Rust)
- **prime-spatial**: degenerate AABB (min==max), zero-component ray direction, large-sphere frustum span
- **prime-signal**: `stiffness=0`, `damping=0`, `smooth_time=0`
- **prime-noise**: large/negative/zero inputs, zero-octave fbm
- **prime-color**: out-of-range sRGB, out-of-gamut Oklab, HSL boundary
- **prime-splines**: degenerate equal control points, `t` outside `[0,1]`
- **prime-diffusion**: `box_muller` near-zero `u1`, `ou_step` with `theta=0`, `gbm_step` with `sigma=mu=0`

### Audit findings — all clear
- Temporal assembly: zero `let`/`var` in TS, zero `&mut` in public Rust
- Math: Catmull-Rom, OU SDE, simplex constants, Lorenz RK4, Oklab matrices — all correct
- Cross-language parity tests present in all packages

**437 Rust tests passing. Clippy clean.**

## Test plan
- [ ] CI Rust + TS + WASM all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)